### PR TITLE
Add MCP tools for job management

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ mention a store or namespace when you need a specific one.
 
 | Tool | Description |
 | ---- | ----------- |
+| Tool | Description |
+| ---- | ----------- |
 | `list_event_stores` | List all event stores on the server. |
 | `list_namespaces` | List namespaces within an event store. |
 | `list_event_types` | List registered event types. |
@@ -119,6 +121,12 @@ mention a store or namespace when you need a specific one.
 | `get_tail_sequence_number` | Get the highest used sequence number (tail) in an event sequence. |
 | `list_recommendations` | List active maintenance recommendations. |
 | `get_server_version` | Get version info from the server (also a connectivity check). |
+| `list_jobs` | List all jobs in a namespace, optionally filtered by job status. |
+| `get_job` | Get a specific job by ID, including full details and status changes. |
+| `get_job_steps` | Get the job steps for a specific job, optionally filtered by step status. |
+| `stop_job` | Stop a specific job (transitions to Stopped status). |
+| `resume_job` | Resume a specific stopped job. |
+| `delete_job` | Delete a specific job (transitions to Removing status). |
 
 You can ask it things like:
 
@@ -128,6 +136,10 @@ You can ask it things like:
 - Show me the events in the [put name here] event store
 - Are there any failed partitions?
 - What observers in the [put event store name here] use event type [put event type name]
+- List all jobs in the [put event store name here] event store
+- Show me job [put job id here] in the [put namespace name here] namespace
+- What steps does job [put job id here] have?
+- Stop / Resume / Delete job [put job id here]
 
 ## Local development
 

--- a/Source/Tools/Jobs/JobDescriptor.cs
+++ b/Source/Tools/Jobs/JobDescriptor.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Jobs;
+
+/// <summary>
+/// A concise description of a job.
+/// </summary>
+/// <param name="Id">The unique identifier of the job.</param>
+/// <param name="Details">The details for the job.</param>
+/// <param name="Type">The type of the job.</param>
+/// <param name="Status">The current status of the job (None, PreparingJob, PreparingSteps, StartingSteps, Running, CompletedSuccessfully, CompletedWithFailures, Stopped, Failed, Removing).</param>
+/// <param name="Created">When the job was created.</param>
+/// <param name="StatusChanges">Collection of status changes that occurred for the job.</param>
+/// <param name="Progress">The current progress of the job.</param>
+public record JobDescriptor(
+    Guid Id,
+    string Details,
+    string Type,
+    string Status,
+    DateTimeOffset Created,
+    IEnumerable<StatusChangeDescriptor> StatusChanges,
+    JobProgressDescriptor Progress);

--- a/Source/Tools/Jobs/JobErrorDescriptor.cs
+++ b/Source/Tools/Jobs/JobErrorDescriptor.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Jobs;
+
+namespace Cratis.Chronicle.Mcp.Tools.Jobs;
+
+/// <summary>
+/// Error information when a job is not found or invalid.
+/// </summary>
+/// <param name="Error">The type of job error (NotFound, TypeIsNotAJobStateType, TypeIsNotAssociatedWithAJobType).</param>
+public record JobErrorDescriptor(JobError Error);

--- a/Source/Tools/Jobs/JobProgressDescriptor.cs
+++ b/Source/Tools/Jobs/JobProgressDescriptor.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Jobs;
+
+/// <summary>
+/// The progress information for a job.
+/// </summary>
+/// <param name="TotalSteps">Total number of steps in the job.</param>
+/// <param name="SuccessfulSteps">Number of completed steps.</param>
+/// <param name="FailedSteps">Number of failed steps.</param>
+/// <param name="StoppedSteps">Number of stopped steps.</param>
+/// <param name="IsCompleted">Whether the job is completed.</param>
+/// <param name="IsStopped">Whether the job is stopped.</param>
+/// <param name="Message">Current progress message.</param>
+public record JobProgressDescriptor(
+    int TotalSteps,
+    int SuccessfulSteps,
+    int FailedSteps,
+    int StoppedSteps,
+    bool IsCompleted,
+    bool IsStopped,
+    string Message);

--- a/Source/Tools/Jobs/JobResult.cs
+++ b/Source/Tools/Jobs/JobResult.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Jobs;
+
+namespace Cratis.Chronicle.Mcp.Tools.Jobs;
+
+/// <summary>
+/// Result of a job operation, containing either a job or an error.
+/// </summary>
+/// <param name="Job">The job descriptor, if found.</param>
+/// <param name="Error">The job error, if the job was not found or invalid.</param>
+public record JobResult(
+    JobDescriptor? Job,
+    JobError? Error)
+{
+    /// <summary>
+    /// Gets whether the result contains an error.
+    /// </summary>
+    public bool HasError => Error.HasValue;
+}

--- a/Source/Tools/Jobs/JobStepDescriptor.cs
+++ b/Source/Tools/Jobs/JobStepDescriptor.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Jobs;
+
+/// <summary>
+/// A concise description of a job step.
+/// </summary>
+/// <param name="Id">The unique identifier of the job step.</param>
+/// <param name="Type">The type of the job step.</param>
+/// <param name="Name">The name of the job step.</param>
+/// <param name="Status">The current status of the job step (Unknown, Scheduled, Running, CompletedSuccessfully, CompletedWithFailure, Stopped, Failed, Removing).</param>
+/// <param name="StatusChanges">Collection of status changes that occurred for the job step.</param>
+/// <param name="Progress">The current progress of the job step.</param>
+public record JobStepDescriptor(
+    Guid Id,
+    string Type,
+    string Name,
+    string Status,
+    IEnumerable<JobStepStatusChangeDescriptor> StatusChanges,
+    JobStepProgressDescriptor? Progress);

--- a/Source/Tools/Jobs/JobStepProgressDescriptor.cs
+++ b/Source/Tools/Jobs/JobStepProgressDescriptor.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Jobs;
+
+/// <summary>
+/// The progress information for a job step.
+/// </summary>
+/// <param name="Percentage">The percentage completion of the step.</param>
+/// <param name="Message">Current progress message.</param>
+public record JobStepProgressDescriptor(
+    int Percentage,
+    string Message);

--- a/Source/Tools/Jobs/JobStepStatusChangeDescriptor.cs
+++ b/Source/Tools/Jobs/JobStepStatusChangeDescriptor.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Jobs;
+
+/// <summary>
+/// A status change event for a job step.
+/// </summary>
+/// <param name="Status">The status at the time of the change.</param>
+/// <param name="Occurred">When the status change occurred.</param>
+/// <param name="ExceptionMessages">Any exception messages associated with the change.</param>
+/// <param name="ExceptionStackTrace">Stack trace for exceptions, if any.</param>
+public record JobStepStatusChangeDescriptor(
+    string Status,
+    DateTimeOffset Occurred,
+    IEnumerable<string> ExceptionMessages,
+    string ExceptionStackTrace);

--- a/Source/Tools/Jobs/JobTools.cs
+++ b/Source/Tools/Jobs/JobTools.cs
@@ -1,0 +1,264 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Jobs;
+using Cratis.Chronicle.Contracts.Primitives;
+using Cratis.Chronicle.Mcp.Configuration;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Jobs;
+
+/// <summary>
+/// Tools for working with jobs in Chronicle.
+/// </summary>
+[McpServerToolType]
+public static class JobTools
+{
+    /// <summary>
+    /// Lists all jobs in a namespace, optionally filtered by status.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace. Defaults to the configured namespace.</param>
+    /// <param name="status">Optional filter by job status. Can be a comma-separated list of statuses.</param>
+    /// <returns>A collection of job descriptors.</returns>
+    [McpServerTool(Name = "list_jobs")]
+    [Description("Lists all jobs in a namespace, optionally filtered by status. Returns a collection of job descriptors with status, progress, and metadata.")]
+    public static async Task<IEnumerable<JobDescriptor>> ListJobs(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace. Defaults to the configured namespace.")] string? @namespace = null,
+        [Description("Optional filter by job status. Can be a comma-separated list of statuses (e.g. 'Running,PreparingJob').")] string? status = null)
+    {
+        var request = new GetJobsRequest
+        {
+            EventStore = configuration.ResolveEventStore(eventStore),
+            Namespace = configuration.ResolveNamespace(@namespace)
+        };
+
+        var jobs = await services.Jobs.GetJobs(request);
+
+        var jobsList = jobs.ToList();
+        var result = jobsList.Select(job => ToDescriptor(job)).ToList();
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            var statusStrings = status
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(s => s.Trim().ToUpperInvariant())
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            if (statusStrings.Count > 0)
+            {
+                result = result.Where(j => statusStrings.Contains(j.Status)).ToList();
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets a specific job by ID.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="jobId">The job identifier.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace. Defaults to the configured namespace.</param>
+    /// <returns>Either a job descriptor with full details including status changes and progress, or a job error.</returns>
+    [McpServerTool(Name = "get_job")]
+    [Description("Gets a specific job by ID. Returns either a job descriptor with full details including status changes and progress, or a job error (NotFound, TypeIsNotAJobStateType, TypeIsNotAssociatedWithAJobType).")]
+    public static async Task<JobResult> GetJob(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The job identifier.")] Guid jobId,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace. Defaults to the configured namespace.")] string? @namespace = null)
+    {
+        var request = new GetJobRequest
+        {
+            EventStore = configuration.ResolveEventStore(eventStore),
+            Namespace = configuration.ResolveNamespace(@namespace),
+            JobId = jobId
+        };
+
+        var result = await services.Jobs.GetJob(request);
+
+        var oneOfValue = result.Value as OneOf<Job, JobError>;
+        return oneOfValue.Value switch
+        {
+            Job job => new JobResult(ToDescriptor(job), null),
+            JobError jobError => new JobResult(null, jobError),
+            _ => throw new InvalidOperationException($"Unknown job result type: {result.Value?.GetType().Name}")
+        };
+    }
+
+    /// <summary>
+    /// Gets the job steps for a specific job.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="jobId">The job identifier.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace. Defaults to the configured namespace.</param>
+    /// <param name="status">Optional filter by job step status. Can be a comma-separated list of statuses.</param>
+    /// <returns>A collection of job step descriptors.</returns>
+    [McpServerTool(Name = "get_job_steps")]
+    [Description("Gets the job steps for a specific job. Returns a collection of job step descriptors with status, progress, and metadata. Optionally filtered by step status.")]
+    public static async Task<IEnumerable<JobStepDescriptor>> GetJobSteps(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The job identifier.")] Guid jobId,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace. Defaults to the configured namespace.")] string? @namespace = null,
+        [Description("Optional filter by job step status. Can be a comma-separated list of statuses (e.g. 'Running,CompletedSuccessfully').")] string? status = null)
+    {
+        var request = new GetJobStepsRequest
+        {
+            EventStore = configuration.ResolveEventStore(eventStore),
+            Namespace = configuration.ResolveNamespace(@namespace),
+            JobId = jobId
+        };
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            foreach (var statusStr in status
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (Enum.TryParse<JobStepStatus>(statusStr, ignoreCase: true, out var parsed))
+                {
+                    request.Statuses = request.Statuses.Concat(new[] { parsed }).ToArray();
+                }
+            }
+        }
+
+        var jobSteps = await services.Jobs.GetJobSteps(request);
+        return jobSteps.Select(ToStepDescriptor);
+    }
+
+    /// <summary>
+    /// Stops a specific job.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="jobId">The job identifier.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace. Defaults to the configured namespace.</param>
+    /// <returns>Awaitable task.</returns>
+    [McpServerTool(Name = "stop_job")]
+    [Description("Stops a specific job. The job will transition to the Stopped status and can be resumed later.")]
+    public static async Task StopJob(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The job identifier.")] Guid jobId,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace. Defaults to the configured namespace.")] string? @namespace = null)
+    {
+        await services.Jobs.Stop(new StopJob
+        {
+            EventStore = configuration.ResolveEventStore(eventStore),
+            Namespace = configuration.ResolveNamespace(@namespace),
+            JobId = jobId
+        });
+    }
+
+    /// <summary>
+    /// Resumes a specific stopped job.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="jobId">The job identifier.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace. Defaults to the configured namespace.</param>
+    /// <returns>Awaitable task.</returns>
+    [McpServerTool(Name = "resume_job")]
+    [Description("Resumes a specific stopped job. The job must be in the Stopped status.")]
+    public static async Task ResumeJob(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The job identifier.")] Guid jobId,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace. Defaults to the configured namespace.")] string? @namespace = null)
+    {
+        await services.Jobs.Resume(new ResumeJob
+        {
+            EventStore = configuration.ResolveEventStore(eventStore),
+            Namespace = configuration.ResolveNamespace(@namespace),
+            JobId = jobId
+        });
+    }
+
+    /// <summary>
+    /// Deletes a specific job.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="jobId">The job identifier.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace. Defaults to the configured namespace.</param>
+    /// <returns>Awaitable task.</returns>
+    [McpServerTool(Name = "delete_job")]
+    [Description("Deletes a specific job. The job will transition to the Removing status and be eventually removed from the system.")]
+    public static async Task DeleteJob(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The job identifier.")] Guid jobId,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace. Defaults to the configured namespace.")] string? @namespace = null)
+    {
+        await services.Jobs.Delete(new DeleteJob
+        {
+            EventStore = configuration.ResolveEventStore(eventStore),
+            Namespace = configuration.ResolveNamespace(@namespace),
+            JobId = jobId
+        });
+    }
+
+    static JobDescriptor ToDescriptor(Job job)
+    {
+        var statusChanges = (job.StatusChanges ?? Enumerable.Empty<JobStatusChanged>()).Select(scs => new StatusChangeDescriptor(
+            scs.Status.ToString(),
+            scs.Occurred,
+            scs.ExceptionMessages ?? [],
+            scs.ExceptionStackTrace ?? string.Empty));
+
+        return new JobDescriptor(
+            job.Id,
+            job.Details ?? string.Empty,
+            job.Type ?? string.Empty,
+            job.Status.ToString(),
+            job.Created,
+            statusChanges,
+            new JobProgressDescriptor(
+                job.Progress.TotalSteps,
+                job.Progress.SuccessfulSteps,
+                job.Progress.FailedSteps,
+                job.Progress.StoppedSteps,
+                job.Progress.IsCompleted,
+                job.Progress.IsStopped,
+                job.Progress.Message ?? string.Empty));
+    }
+
+    static JobStepDescriptor ToStepDescriptor(JobStep jobStep)
+    {
+        var statusChanges = (jobStep.StatusChanges ?? Enumerable.Empty<JobStepStatusChanged>()).Select(sc => new JobStepStatusChangeDescriptor(
+            sc.Status.ToString(),
+            sc.Occurred,
+            sc.ExceptionMessages ?? Array.Empty<string>(),
+            sc.ExceptionStackTrace ?? string.Empty));
+
+        return new JobStepDescriptor(
+            jobStep.Id,
+            jobStep.Type ?? string.Empty,
+            jobStep.Name ?? string.Empty,
+            jobStep.Status.ToString(),
+            statusChanges,
+            jobStep.Progress is not null ? new JobStepProgressDescriptor(
+                jobStep.Progress.Percentage,
+                jobStep.Progress.Message ?? string.Empty) : null);
+    }
+}

--- a/Source/Tools/Jobs/StatusChangeDescriptor.cs
+++ b/Source/Tools/Jobs/StatusChangeDescriptor.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Jobs;
+
+/// <summary>
+/// A status change event for a job.
+/// </summary>
+/// <param name="Status">The status at the time of the change.</param>
+/// <param name="Occurred">When the status change occurred.</param>
+/// <param name="ExceptionMessages">Any exception messages associated with the change.</param>
+/// <param name="ExceptionStackTrace">Stack trace for exceptions, if any.</param>
+public record StatusChangeDescriptor(
+    string Status,
+    DateTimeOffset Occurred,
+    IEnumerable<string> ExceptionMessages,
+    string ExceptionStackTrace);


### PR DESCRIPTION
## Added
- `list_jobs`: Lists all jobs in a namespace, optionally filtered by job status
- `get_job`: Gets a specific job by ID with full details and status changes
- `get_job_steps`: Gets the job steps for a specific job, optionally filtered by step status
- `stop_job`: Stops a specific job (transitions to Stopped status)
- `resume_job`: Resumes a specific stopped job
- `delete_job`: Deletes a specific job (transitions to Removing status)
