### PR TITLE
Add design-time tools and update to Chronicle 16.x

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle.Connections" Version="15.40.0" />
-    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="15.40.0" />
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.2" />
+    <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.0.6" />
+    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.0.6" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.4" />
     <!-- Roslyn-->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />

--- a/Documentation/concepts.md
+++ b/Documentation/concepts.md
@@ -1,0 +1,42 @@
+# How it works
+
+The Chronicle MCP server exposes two kinds of capability over one connection. Understanding the split is the fastest way to know which tool an agent will reach for — and why the design-time tools can be trusted not to make things up.
+
+```mermaid
+flowchart LR
+    Agent[AI agent] -->|MCP over stdio| Server[Chronicle MCP server]
+    Server -->|gRPC| Chronicle[(Chronicle store)]
+    subgraph Server
+        Operate[Operate-side tools]
+        Design[Design-time tools]
+    end
+    Operate -.->|inspect & operate| Chronicle
+    Design -.->|introspect schema| Chronicle
+    Design -->|propose code| Review[Reviewable proposal]
+```
+
+## Two modes
+
+**Operate-side** is about *inspecting and operating a live system*. These tools read events, list observers, report failed partitions, and manage jobs. They are the natural-language equivalent of running the [Cratis CLI](https://github.com/Cratis/cli) against a store. See [Operating a store](operate-side/index.md).
+
+**Design-time** is about *turning intent into Chronicle artifacts*. Given a plain request, these tools introspect the store's registered schema and produce read models, projections, audits, and catalogs. They are deliberately generative and advisory rather than operational. See [Design-time capabilities](design-time/index.md).
+
+The two are complementary: an agent might use operate-side tools to discover what event types exist, then a design-time tool to scaffold a read model from them.
+
+## Grounding over fluency
+
+Every design-time capability rests on one principle: **introspect the store before generating anything.** Field names, types, and event names come from Chronicle's schema — never from a guess.
+
+- Event fields are read from the JSON schema registered with each event type, exposed through [describe an event type](design-time/describe-event-type.md).
+- Consumers (projections, reducers, reactors) are read from the store's projection and observer definitions.
+- When the store does not have enough information to answer confidently — for example a requested event type is not registered — the tool says so and returns no fabricated shape, rather than inventing one.
+
+This is worth over-engineering relative to the natural-language parsing itself: a plausible-sounding but wrong field name is worse than a tool that asks a clarifying question.
+
+## Read-only against the store, generative against your codebase
+
+No design-time capability mutates the store. They need only read access to the event type registry, projection and observer definitions, and namespaces. Generated code is returned as a proposal — the agent shows it to you, and you review it like any other change and apply it to your own project. Projections are cheap to regenerate but should never appear unreviewed in a codebase.
+
+## Multi-tenancy awareness
+
+Chronicle isolates tenants by namespace. Every tool is scoped to an event store and namespace — defaulting to your configured defaults, overridable per call — so one tenant's event shapes never leak into another's suggestions by accident.

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -1,0 +1,49 @@
+# Configuration
+
+Configuration is optional. The server works out of the box with defaults suited to local development:
+
+- **Connection string:** `chronicle://localhost:35000/?disableTls=true`
+- **Credentials:** the development client id (`chronicle-dev-client`) and secret (`chronicle-dev-secret`)
+- **Event store / namespace:** `default` / `Default`
+
+You only set values when you need to point at a different server or authenticate against a secured one.
+
+## Resolution order
+
+For every value the server has not been given explicitly, it resolves in this order, first match wins:
+
+1. Explicit MCP options — environment variables or `appsettings.json`.
+2. The `CHRONICLE_CONNECTION_STRING` environment variable.
+3. The active context in the Cratis CLI configuration at `~/.cratis/config.json`.
+4. Built-in development defaults.
+
+Because step 3 reads the same file the [Cratis CLI](https://github.com/Cratis/cli) writes, a store you have already set up with `cratis context create` is picked up automatically — no separate configuration.
+
+## Options
+
+All options live under the `Cratis:Chronicle:Mcp` configuration section. As environment variables they take the `Cratis__Chronicle__Mcp__` prefix:
+
+| Option | Environment variable | Description |
+| ------ | -------------------- | ----------- |
+| `ConnectionString` | `Cratis__Chronicle__Mcp__ConnectionString` | The Chronicle connection string. Defaults to `chronicle://localhost:35000/?disableTls=true`. |
+| `Context` | `Cratis__Chronicle__Mcp__Context` | The CLI context to read connection details from. Defaults to the active context. |
+| `UseCliConfiguration` | `Cratis__Chronicle__Mcp__UseCliConfiguration` | Set to `false` to ignore `~/.cratis/config.json` entirely. |
+| `ClientId` / `ClientSecret` | `Cratis__Chronicle__Mcp__ClientId` / `...__ClientSecret` | Client credentials for authentication. Defaults to development credentials. |
+| `ApiKey` | `Cratis__Chronicle__Mcp__ApiKey` | An API key to authenticate with, as an alternative to client credentials. |
+| `EventStore` | `Cratis__Chronicle__Mcp__EventStore` | The default event store used by tools when none is specified. Defaults to `default`. |
+| `Namespace` | `Cratis__Chronicle__Mcp__Namespace` | The default namespace used by tools when none is specified. Defaults to `Default`. |
+
+Every tool defaults the event store and namespace to these configured values, so you can ask high-level questions and only name a store or namespace when you need a specific one.
+
+## Authentication
+
+The server authenticates the same way the CLI does, and shares its token cache:
+
+- **Client credentials (OAuth):** when the connection string carries a client id and secret (or you set `ClientId`/`ClientSecret`), the server obtains an OAuth token from the server's token endpoint, derived from the connection's own address. Tokens are cached on disk under `~/.cratis/tokens`, the same location the CLI uses, so the two share credentials.
+- **API key:** set `ApiKey` (or embed `apiKey=` in the connection string) to authenticate with a static key instead.
+
+> The token endpoint is taken from the connected server's address; there is no separate management-port setting. If you are upgrading from an older release that had a `ManagementPort` option, you can remove it — it no longer has any effect.
+
+## Connect timeout
+
+Set `CHRONICLE_CONNECT_TIMEOUT_SECONDS` to override the default 5-second connect timeout when reaching a slow or remote server.

--- a/Documentation/design-time/causal-trace.md
+++ b/Documentation/design-time/causal-trace.md
@@ -1,0 +1,41 @@
+# Causal trace
+
+`explain_causal_trace` reads the ordered event history of one event source together with each event's correlation id and causation chain, so an agent can narrate *what happened and why* instead of a support engineer reading raw JSON logs. It is the natural-language equivalent of `git blame` for state.
+
+## When to use it
+
+- To answer a question like *"Why does this order show as cancelled?"* for support or operations staff.
+- To reconstruct the sequence of facts that produced an entity's current state.
+- To relate an event to the wider flow that produced it, by following its correlation id.
+
+## Parameters
+
+| Parameter | Required | Description |
+| --------- | -------- | ----------- |
+| `eventSourceId` | yes | The event source id to trace (for example the order id). |
+| `eventSequenceId` | no | The event sequence to read from. Defaults to `event-log`. |
+| `eventType` | no | A comma-separated event type filter. |
+| `eventStore` | no | The event store. Defaults to the configured event store. |
+| `namespace` | no | The namespace. Defaults to the configured namespace. |
+
+## What it returns
+
+The event source's events in sequence order. Each event carries:
+
+- Its sequence number, event type, generation, and when it occurred.
+- Its **correlation id** — the key that groups it with the wider flow it belongs to.
+- The identity that **caused** it, when known.
+- Its **causation** chain — the recorded causes, each with a type and details.
+- The event payload as JSON.
+
+## Example
+
+**Prompt:** *"Why does order 8a3f… show as cancelled?"*
+
+The agent calls `explain_causal_trace` with the order's id and walks the returned timeline: `OrderPlaced`, then `PaymentFailed` sharing a correlation id with a payment retry flow, then `OrderCancelled` caused by that failure. From the ordered facts and their causation, the agent produces a plain-language narrative — "the order was cancelled because payment failed twice" — without anyone reading the raw log.
+
+To widen the picture beyond a single entity, follow the correlation ids: events that share a correlation id belong to the same business flow, even across event sources.
+
+## Related
+
+- [Get events](../operate-side/events.md) — read raw events from a sequence with filtering.

--- a/Documentation/design-time/describe-event-type.md
+++ b/Documentation/design-time/describe-event-type.md
@@ -1,0 +1,42 @@
+# Describe an event type
+
+`describe_event_type` reads an event type's real schema from the store — every property with its JSON type and a suggested C# type. It is the grounding primitive the other design-time tools build on: any generated projection, read model, or spec starts from the fields the event actually carries, not a guess.
+
+## When to use it
+
+- Before generating anything from an event type, to confirm its shape.
+- To answer "what fields does `UserRegistered` have?" without opening source code.
+- As the first step when an agent maps a natural-language request onto concrete events.
+
+## Parameters
+
+| Parameter | Required | Description |
+| --------- | -------- | ----------- |
+| `eventType` | yes | The event type id/name to describe (for example `UserRegistered`). |
+| `generation` | no | A specific generation to describe. The latest is used when omitted. |
+| `eventStore` | no | The event store. Defaults to the configured event store. |
+
+## What it returns
+
+The event type's identity (id, generation, owner, source, whether it is a tombstone, and the originating store when it is a foreign type received through the inbox), plus a list of properties. Each property carries its name, JSON schema type, a suggested C# type, any schema `format`, whether it is required, and its description.
+
+Returns `null` when no matching event type is registered — a signal that the name is wrong or the type has not been registered yet.
+
+## Example
+
+**Prompt:** *"What does the UserRegistered event look like?"*
+
+The agent calls `describe_event_type` with `eventType: "UserRegistered"` and gets back the grounded shape:
+
+| Property | JSON type | C# type | Required |
+| -------- | --------- | ------- | -------- |
+| `Email` | string | `string` | yes |
+| `Name` | string | `string` | no |
+| `RegisteredAt` | string (date-time) | `DateTimeOffset` | no |
+
+The C# type suggestions map JSON schema types and formats to idiomatic C# — `guid`/`uuid` to `Guid`, `date-time` to `DateTimeOffset`, `integer` to `int`, arrays to `IEnumerable<T>`, and so on.
+
+## Related
+
+- [Read-model scaffolding](read-model-scaffolding.md) uses these fields to build a read model.
+- [Event catalog](event-catalog.md) returns the same field detail for every event type at once.

--- a/Documentation/design-time/event-catalog.md
+++ b/Documentation/design-time/event-catalog.md
@@ -1,0 +1,38 @@
+# Event catalog
+
+`generate_event_catalog` produces a living data dictionary from the event store: every event type, its fields, and every projection, reducer, and reactor that consumes it. Event names are the ubiquitous language of an event-sourced system, and this keeps that language documented and current straight from the store — useful onboarding material for new developers and grounding for any modeling question.
+
+## When to use it
+
+- To onboard someone to a domain without hand-maintained documentation.
+- As grounding before a modeling conversation — the agent reads the catalog to know what already exists.
+- To regenerate a data dictionary on demand instead of maintaining one by hand.
+
+## Parameters
+
+| Parameter | Required | Description |
+| --------- | -------- | ----------- |
+| `eventStore` | no | The event store. Defaults to the configured event store. |
+| `namespace` | no | The namespace to resolve observers in. Defaults to the configured namespace. |
+| `eventType` | no | A single event type id to scope the catalog to. Omit for the whole store. |
+
+## What it returns
+
+One entry per event type, each with:
+
+- **Identity** — id, generation, owner, source, whether it is a tombstone, and the originating store for foreign types.
+- **Fields** — every property with its JSON and suggested C# type, the same detail as [describe an event type](describe-event-type.md).
+- **Consumers** — the projections, reducers, and reactors that read the event, each with its type, identifier, and the read model it builds (when it builds one).
+
+An event type with an empty consumer list is an orphan — the same signal the [unconsumed-event audit](unconsumed-event-audit.md) isolates.
+
+## Example
+
+**Prompt:** *"Give me a catalog of our order events and who reads them."*
+
+Scoped with `eventType` or filtered by the agent, the catalog shows, for each order event, its fields and its consumers — for example that `OrderPlaced` is read by the `OrderSummary` projection and the `ShippingNotifier` reactor, while `OrderCancelled` is read only by `OrderSummary`. From there the agent can explain the read side of the domain, or spot a gap.
+
+## Related
+
+- [Describe an event type](describe-event-type.md) — the same field detail for a single type.
+- [Unconsumed-event audit](unconsumed-event-audit.md) — a focused view of the orphans in the catalog.

--- a/Documentation/design-time/index.md
+++ b/Documentation/design-time/index.md
@@ -1,0 +1,27 @@
+# Design-time capabilities
+
+The design-time tools turn a plain-language request into Chronicle artifacts — read models, projections, audits, and catalogs — grounded in the store's real schema. They are read-only against the store and generative against your codebase: nothing is written to the store, and generated code comes back as a proposal you review. See [How it works](../concepts.md) for the principle behind them.
+
+## Capabilities
+
+| Capability | Tool | Use it to |
+| ---------- | ---- | --------- |
+| [Describe an event type](describe-event-type.md) | `describe_event_type` | Read an event type's real fields and types — the grounding primitive the others build on. |
+| [Read-model scaffolding](read-model-scaffolding.md) | `scaffold_read_model` | Turn a set of event types into a reviewable read model + projection, grounded in their schema. |
+| [Unconsumed-event audit](unconsumed-event-audit.md) | `audit_unconsumed_event_types` | Find events nothing reads, and consumers pointing at event types that no longer exist. |
+| [Event catalog](event-catalog.md) | `generate_event_catalog` | Produce a living data dictionary — every event, its fields, and its consumers. |
+| [Causal trace](causal-trace.md) | `explain_causal_trace` | Turn an event source's raw log into a "what happened and why" narrative. |
+
+## How an agent combines them
+
+A typical flow chains a few tools. To answer *"Show me all the users registered"* an agent might:
+
+1. Resolve candidate event types (`list_event_types`, or [Event catalog](event-catalog.md)).
+2. Inspect their real fields with [describe an event type](describe-event-type.md).
+3. Check whether a projection already answers the question, then propose one with [read-model scaffolding](read-model-scaffolding.md).
+
+Because the tools return structured data rather than prose, the agent does the natural-language reasoning while the store supplies the facts.
+
+## Roadmap
+
+The [capability hand-off](https://github.com/Cratis/Chronicle.Mcp) sketches ten design-time capabilities. The five above are the grounding-and-generation core. The remaining ideas — missing-event-type suggestions, projection-vs-reducer advice, consistency-boundary (DCB) advice, schema-evolution assistance, spec scaffolding, and constraint suggestions — build on the same introspection pipeline and are candidates for future releases.

--- a/Documentation/design-time/read-model-scaffolding.md
+++ b/Documentation/design-time/read-model-scaffolding.md
@@ -1,0 +1,78 @@
+# Read-model scaffolding
+
+`scaffold_read_model` is the flagship design-time capability. It turns a set of event types into a reviewable read model and its model-bound projection — with field names and types taken from the events' real schema, never invented. The output is always a proposal to review, never a silent write into your codebase.
+
+## When to use it
+
+- To answer a request like *"Show me all the users registered"* with a working starting point in seconds instead of hand-written boilerplate.
+- When product or analytics folks describe a read model in plain English and an engineer needs something to approve in a pull request.
+
+The agent resolves the natural-language request to a concrete list of event types first — with [list event types](../operate-side/exploring-the-store.md), [describe an event type](describe-event-type.md), or the [event catalog](event-catalog.md) — then passes them to this tool.
+
+## Parameters
+
+| Parameter | Required | Description |
+| --------- | -------- | ----------- |
+| `readModelName` | yes | The name of the read model to generate (for example `Users`). |
+| `eventTypes` | yes | A comma-separated list of event type ids to project from (for example `UserRegistered,UserEmailVerified`). |
+| `codeNamespace` | no | The C# namespace to generate into. Defaults to `ReadModels`. |
+| `eventStore` | no | The event store. Defaults to the configured event store. |
+
+## What it returns
+
+- **Generated C# code** for a model-bound read model and projection.
+- **Chosen fields**, each traced back to the event it came from, so you can see why every property is there.
+- **Existing projections** that already read these events or target this read model — surfaced so you do not create a duplicate.
+- **Resolved and unresolved event types** — the requested types that were found, and any that are not registered.
+- **Notes** on caveats, such as a property that appears with two different types across events, or an identity that should become a strongly-typed concept.
+
+If none of the requested event types are registered, it returns no code and says so, rather than fabricating a shape.
+
+## Example
+
+**Prompt:** *"Show me all the users registered."*
+
+The agent resolves the request to the `UserRegistered` event, then calls `scaffold_read_model` with `readModelName: "Users"` and `eventTypes: "UserRegistered"`. The generated code is grounded in `UserRegistered`'s real fields:
+
+```csharp
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Driver;
+
+namespace ReadModels;
+
+/// <summary>
+/// Users read model, scaffolded from UserRegistered.
+/// Review the field selection and replace the Guid identity with a strongly-typed EventSourceId concept before use.
+/// </summary>
+[ReadModel]
+[FromEvent<UserRegistered>]
+public record Users(
+    Guid Id,
+    string Email,
+    string Name)
+{
+    /// <summary>
+    /// Queries all Users instances.
+    /// </summary>
+    /// <param name="collection">The read model collection.</param>
+    /// <returns>All Users instances.</returns>
+    public static IQueryable<Users> AllUsers(IMongoCollection<Users> collection) =>
+        collection.AsQueryable();
+}
+```
+
+## Reviewing the proposal
+
+The scaffold is a starting point, not a finished slice. When you review it:
+
+- **Identity.** The key is generated as `Guid Id`. Replace it with a strongly-typed identity concept derived from `EventSourceId<Guid>` — the note on the result reminds you.
+- **AutoMap.** Field names match the event's property names so Chronicle's AutoMap wires them; keep names aligned or add explicit mapping where they diverge.
+- **`using` directives.** `[ReadModel]` and `[FromEvent<T>]` come from Chronicle; most Cratis projects surface them through global usings. Adjust the usings to match your project.
+- **Existing projections.** If the result lists an existing projection that already answers the question, prefer surfacing that over adding a duplicate.
+
+## Related
+
+- [Describe an event type](describe-event-type.md) — inspect the fields before scaffolding.
+- [Unconsumed-event audit](unconsumed-event-audit.md) — find events that still lack a read model.

--- a/Documentation/design-time/toc.yml
+++ b/Documentation/design-time/toc.yml
@@ -1,0 +1,12 @@
+- name: Overview
+  href: index.md
+- name: Describe an event type
+  href: describe-event-type.md
+- name: Read-model scaffolding
+  href: read-model-scaffolding.md
+- name: Unconsumed-event audit
+  href: unconsumed-event-audit.md
+- name: Event catalog
+  href: event-catalog.md
+- name: Causal trace
+  href: causal-trace.md

--- a/Documentation/design-time/unconsumed-event-audit.md
+++ b/Documentation/design-time/unconsumed-event-audit.md
@@ -1,0 +1,46 @@
+# Unconsumed-event audit
+
+`audit_unconsumed_event_types` cross-references every registered event type against everything that consumes it — projections, reducers, and reactors — and reports two kinds of silent data debt:
+
+- **Unconsumed event types** — data being written that no read model or reactor reads.
+- **Dangling references** — the inverse: a consumer that references an event type id which no longer exists in the registry, typically a dead projection left behind after a refactor.
+
+It needs no natural-language parsing and is cheap to run, which makes it a good periodic health check rather than only an ad-hoc query.
+
+## When to use it
+
+- As a recurring audit to catch events recorded "just in case" that never became a read model.
+- After a refactor, to find projections or reducers still pointing at event types that have been removed.
+
+## Parameters
+
+| Parameter | Required | Description |
+| --------- | -------- | ----------- |
+| `eventStore` | no | The event store. Defaults to the configured event store. |
+| `namespace` | no | The namespace to resolve observers in. Defaults to the configured namespace. |
+
+## What it returns
+
+- The number of event types considered.
+- **Unconsumed** event types, each with its id, generation, owner, and whether it is a tombstone. The owner tells you whether it is a `Client` type a developer usually cares about or a framework-internal `Chronicle` type.
+- **Dangling references**, each naming the missing event type id and the consumer (its type and id) that still points at it.
+
+## How consumption is determined
+
+The audit is grounded entirely in the store's registered definitions:
+
+- **Projections** contribute the event types they read from — the keys of their `From`, `Join`, and removal definitions, walked into nested and child projections.
+- **Observers** (reactors, reducers, and projections) contribute the event types each observes.
+
+An event type is *unconsumed* when nothing in either set references it. A reference is *dangling* when it names an event type id that is not in the registry.
+
+## Example
+
+**Prompt:** *"What events are we writing that nothing reads?"*
+
+The agent calls `audit_unconsumed_event_types` and reports back, for example, that `CartAbandoned` is written but read by no projection or reactor — a candidate for either a new read model or removal — and that a `LegacyOrderView` projection still references a `PriceQuoted` event type that no longer exists.
+
+## Related
+
+- [Event catalog](event-catalog.md) — the full picture of every event and its consumers, including the orphans this audit isolates.
+- [Read-model scaffolding](read-model-scaffolding.md) — turn an unconsumed event into a read model.

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -1,0 +1,53 @@
+# Getting started
+
+By the end of this page you will have the Chronicle MCP server running inside your agent and answering questions about a live Chronicle store.
+
+## Prerequisites
+
+- A running Chronicle server. If you do not have one, the `docker-compose.yml` in the [`Source`](../Source/docker-compose.yml) folder brings one up with `docker compose up -d`.
+- An MCP-capable agent (for example VS Code with an agent extension, or any client that speaks the Model Context Protocol over stdio).
+- Docker, to run the pre-built `cratis/chronicle-mcp` image.
+
+## Wire it into your agent
+
+The server speaks MCP over stdio and ships as a container. Configure your agent to launch it. In VS Code, add it to your user settings or to a `.vscode/mcp.json` in your project:
+
+```json
+{
+    "servers": {
+        "Chronicle": {
+            "type": "stdio",
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "-eCratis__Chronicle__Mcp__ConnectionString=chronicle://host.docker.internal:35000",
+                "cratis/chronicle-mcp"
+            ]
+        }
+    }
+}
+```
+
+On macOS and Windows the host machine is reachable from the container at `host.docker.internal`. The connection string is the only value most setups need to change — everything else has a working local-development default. See [Configuration](configuration.md) for the full resolution order and authentication.
+
+## Ask your first questions
+
+Once the server is connected, your agent can reach the store. Start with the operate-side capabilities to confirm connectivity:
+
+- "List all event stores."
+- "What event types are registered?"
+- "Are there any failed partitions?"
+
+Then try the design-time capabilities, which turn a plain request into a grounded artifact:
+
+- "Show me all the users registered" → the agent resolves the event types, then proposes a read model with [read-model scaffolding](design-time/read-model-scaffolding.md).
+- "What events are we writing that nothing reads?" → an [unconsumed-event audit](design-time/unconsumed-event-audit.md).
+- "Why does this order show as cancelled?" → a [causal trace](design-time/causal-trace.md) of the order's history.
+
+## Where to go next
+
+- [Configuration](configuration.md) — connect to a secured server, share the CLI's context, or run without Docker.
+- [How it works](concepts.md) — the two modes and why every design-time suggestion is grounded in real schema.
+- [Design-time capabilities](design-time/index.md) — the full set of generative and advisory tools.

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -1,0 +1,24 @@
+# Chronicle MCP Server
+
+The Chronicle MCP server connects an AI agent to a running [Cratis Chronicle](https://github.com/Cratis/Chronicle) event store over the [Model Context Protocol](https://modelcontextprotocol.io). Point your agent at a Chronicle server and it can explore the domain, operate observers and jobs, and turn plain-language requests into Chronicle artifacts — always grounded in the store's real schema.
+
+The server offers two complementary sets of capabilities:
+
+| Mode | What it does | Start here |
+| ---- | ------------ | ---------- |
+| **Operate-side** | Inspect and operate a live system — browse events, watch observers, replay partitions, manage jobs. | [Operating a store](operate-side/index.md) |
+| **Design-time** | Turn natural language into Chronicle artifacts — read models, projections, audits, catalogs — grounded in the actual event schema, never guessed. | [Design-time capabilities](design-time/index.md) |
+
+## Get started
+
+By the end of [Getting started](getting-started.md) you will have the server wired into your agent and answering questions about a running Chronicle store.
+
+1. [Getting started](getting-started.md) — wire the server into your agent and ask your first question.
+2. [Configuration](configuration.md) — connection string, CLI config sharing, and authentication.
+3. [How it works](concepts.md) — the design-time vs. operate-side split and the grounding principle.
+
+## Why this exists
+
+Chronicle already exposes a rich gRPC management API, and the [Cratis CLI](https://github.com/Cratis/cli) puts it at your fingertips. This server puts the same store in reach of an AI agent — so instead of you translating a question into a sequence of API calls, the agent does it, and instead of hand-writing read-model boilerplate, the agent proposes a grounded starting point you review like any other change.
+
+The design-time capabilities never invent field names or event shapes. Every suggestion is introspected from what the store actually has registered — see [How it works](concepts.md#grounding-over-fluency).

--- a/Documentation/operate-side/events.md
+++ b/Documentation/operate-side/events.md
@@ -1,0 +1,30 @@
+# Events
+
+These tools read from event sequences — the append-only logs at the heart of Chronicle.
+
+## Tools
+
+| Tool | Description |
+| ---- | ----------- |
+| `get_events` | Retrieve events from an event sequence, with optional filtering by sequence range, event source id, and event type. Returns event headers and JSON content. |
+| `get_tail_sequence_number` | Return the highest used sequence number (the tail) in an event sequence. |
+
+## `get_events`
+
+| Parameter | Description |
+| --------- | ----------- |
+| `eventSequenceId` | The sequence to read from. Defaults to `event-log`. |
+| `from` / `to` | The sequence-number range. `from` defaults to `0`; `to` is optional. |
+| `eventSourceId` | An optional event source id to filter by. |
+| `eventType` | An optional comma-separated event type filter (for example `UserRegistered` or `UserRegistered+1`). |
+| `eventStore` / `namespace` | Default to the configured values. |
+
+Use it to read what actually happened — for a whole sequence, a range, or a single event source.
+
+## `get_tail_sequence_number`
+
+The tail is the highest used sequence number, not a total count of events — gaps can exist. Use it to gauge how far a sequence has progressed, for example when checking whether an observer has caught up.
+
+## Narrating history
+
+`get_events` returns raw events. To turn one event source's history into a "what happened and why" narrative — following correlation and causation — use the design-time [causal trace](../design-time/causal-trace.md) tool instead.

--- a/Documentation/operate-side/exploring-the-store.md
+++ b/Documentation/operate-side/exploring-the-store.md
@@ -1,0 +1,29 @@
+# Exploring the store
+
+These tools let an agent walk a Chronicle store's structure — its stores, namespaces, event types, projections, read models, and current instances — to build up a picture of the domain before doing anything else.
+
+## Tools
+
+| Tool | Description |
+| ---- | ----------- |
+| `get_server_version` | Get version info from the server. Doubles as a connectivity check. |
+| `list_event_stores` | List all event stores on the server. |
+| `list_namespaces` | List namespaces within an event store. |
+| `list_event_types` | List registered event types, with id, generation, owner, and source. |
+| `list_projections` | List projection definitions, including the read model each projects into and its activity state. |
+| `list_read_models` | List read model definitions. |
+| `get_read_model_instances` | List the current instances of a read model, paged. |
+
+## Typical flow
+
+Start broad and narrow down:
+
+1. `get_server_version` — confirm the server is reachable.
+2. `list_event_stores` then `list_namespaces` — find the store and tenant you care about.
+3. `list_event_types` — see the domain's vocabulary.
+4. `list_projections` and `list_read_models` — see what is already derived from those events.
+5. `get_read_model_instances` — read the current state a projection has produced.
+
+## Going deeper on an event type
+
+`list_event_types` gives you the inventory. To see an event type's actual fields and types, use the design-time [describe an event type](../design-time/describe-event-type.md) tool, or [generate an event catalog](../design-time/event-catalog.md) for the whole store at once.

--- a/Documentation/operate-side/index.md
+++ b/Documentation/operate-side/index.md
@@ -1,0 +1,25 @@
+# Operating a store
+
+The operate-side tools inspect and operate a live Chronicle system. They are the natural-language equivalent of running the [Cratis CLI](https://github.com/Cratis/cli) against a store: browse the domain, watch observers, read events, and manage jobs. Every tool defaults the event store and namespace to your [configured defaults](../configuration.md), so you only name a store or namespace when you want a specific one.
+
+## Capabilities
+
+| Area | Tools | Page |
+| ---- | ----- | ---- |
+| Exploring the store | `list_event_stores`, `list_namespaces`, `list_event_types`, `list_projections`, `list_read_models`, `get_read_model_instances`, `get_server_version` | [Exploring the store](exploring-the-store.md) |
+| Events | `get_events`, `get_tail_sequence_number` | [Events](events.md) |
+| Observer health | `list_observers`, `get_observer`, `list_failed_partitions`, `list_recommendations` | [Observer health](observer-health.md) |
+| Jobs | `list_jobs`, `get_job`, `get_job_steps`, `stop_job`, `resume_job`, `delete_job` | [Jobs](jobs.md) |
+
+## Things to ask
+
+- List all event stores.
+- List all event types in the `orders` event store.
+- Show me the events for order `8a3f…`.
+- Are there any failed partitions?
+- What observers use the event type `OrderPlaced`?
+- List all jobs, and show me the steps of job `…`.
+
+## Operate-side and design-time together
+
+Operate-side tools discover *what is there*; design-time tools turn that into *artifacts*. A common pattern is to explore event types here, then hand them to [read-model scaffolding](../design-time/read-model-scaffolding.md). See [How it works](../concepts.md) for the full split.

--- a/Documentation/operate-side/jobs.md
+++ b/Documentation/operate-side/jobs.md
@@ -1,0 +1,25 @@
+# Jobs
+
+Chronicle runs long-lived work — replays, projections rebuilds, and other maintenance — as jobs. These tools let an agent list jobs, inspect their progress and steps, and control their lifecycle.
+
+## Tools
+
+| Tool | Description |
+| ---- | ----------- |
+| `list_jobs` | List all jobs in a namespace, optionally filtered by job status. |
+| `get_job` | Get a specific job by id, including full details and status changes. |
+| `get_job_steps` | Get the steps of a specific job, optionally filtered by step status. |
+| `stop_job` | Stop a specific job. It transitions to a stopped status. |
+| `resume_job` | Resume a specific stopped job. |
+| `delete_job` | Delete a specific job. It transitions to a removing status. |
+
+## Typical flow
+
+1. `list_jobs` — see what is running or has run, filtered by status when you only care about, say, failed jobs.
+2. `get_job` — inspect one job's details and the history of its status changes.
+3. `get_job_steps` — drill into the individual steps to see where a job is or where it stopped.
+4. `stop_job` / `resume_job` / `delete_job` — control the job once you understand its state.
+
+## A note on control operations
+
+`stop_job`, `resume_job`, and `delete_job` change a running system. Have the agent confirm the job id and its current state — with `get_job` — before invoking them, the same care you would take from the CLI.

--- a/Documentation/operate-side/observer-health.md
+++ b/Documentation/operate-side/observer-health.md
@@ -1,0 +1,27 @@
+# Observer health
+
+Observers — projections, reducers, and reactors — consume event sequences to build read models and trigger side effects. These tools let an agent check their health, find failures, and surface maintenance the store recommends.
+
+## Tools
+
+| Tool | Description |
+| ---- | ----------- |
+| `list_observers` | List observers in a namespace, with health and replay status. Optionally filter by type (reactor, reducer, projection, or all). |
+| `get_observer` | Show detailed information about a specific observer — its type, running state, owner, handled sequence numbers, and observed event types. |
+| `list_failed_partitions` | List observer partitions that have failed and are paused. |
+| `list_recommendations` | List active maintenance recommendations the store has raised. |
+
+## A troubleshooting flow
+
+When an observer is stuck or a read model looks stale:
+
+1. `list_observers` — check the observer's running state and how far its sequence numbers have progressed.
+2. `get_observer` — inspect the observer in detail, including which event types it observes.
+3. `list_failed_partitions` — see whether a partition has failed and paused the observer.
+4. `list_recommendations` — see whether the store already recommends a fix.
+
+A **quarantined** observer does not auto-resume; an operator has to clear the quarantine. Use the [Cratis CLI](https://github.com/Cratis/cli) or the management API to replay, retry, or clear quarantine once you have diagnosed the cause here.
+
+## Finding the consumers of an event type
+
+`get_observer` shows the event types a single observer consumes. For the reverse — every consumer of a given event type across the store, plus its fields — use the design-time [event catalog](../design-time/event-catalog.md).

--- a/Documentation/operate-side/toc.yml
+++ b/Documentation/operate-side/toc.yml
@@ -1,0 +1,10 @@
+- name: Overview
+  href: index.md
+- name: Exploring the store
+  href: exploring-the-store.md
+- name: Events
+  href: events.md
+- name: Observer health
+  href: observer-health.md
+- name: Jobs
+  href: jobs.md

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -1,0 +1,12 @@
+- name: Overview
+  href: index.md
+- name: Getting started
+  href: getting-started.md
+- name: Configuration
+  href: configuration.md
+- name: How it works
+  href: concepts.md
+- name: Operate-side
+  href: operate-side/toc.yml
+- name: Design-time
+  href: design-time/toc.yml

--- a/README.md
+++ b/README.md
@@ -71,13 +71,12 @@ You can see this in action in the [mcp.json](./.vscode/mcp.json) in this reposit
 
 - **Connection String:** `chronicle://host.docker.internal:35000/?disableTls=true`
 - **Credentials:** Development client ID (`chronicle-dev-client`) and secret (`chronicle-dev-secret`)
-- **Management Port:** `8080`
 
 If you need to customize any settings, the MCP server can be configured entirely on its own and is also compatible with the
 [Cratis CLI](https://github.com/Cratis/cli). For any value you do not set explicitly, the server resolves it in this order:
 
 1. Explicit MCP options (environment variables / `appsettings.json`).
-2. The `CHRONICLE_CONNECTION_STRING` / `CHRONICLE_MANAGEMENT_PORT` environment variables.
+2. The `CHRONICLE_CONNECTION_STRING` environment variable.
 3. The active context in the CLI configuration at `~/.cratis/config.json`.
 4. Built-in development defaults.
 
@@ -90,7 +89,6 @@ they use the `Cratis__Chronicle__Mcp__` prefix:
 | Option | Environment variable | Description |
 | ------ | -------------------- | ----------- |
 | `ConnectionString` | `Cratis__Chronicle__Mcp__ConnectionString` | The Chronicle connection string. Defaults to `chronicle://localhost:35000/?disableTls=true`. |
-| `ManagementPort` | `Cratis__Chronicle__Mcp__ManagementPort` | Management port for the HTTP API and token endpoint. Defaults to `8080`. |
 | `Context` | `Cratis__Chronicle__Mcp__Context` | The CLI context to read connection details from (defaults to the active context). |
 | `UseCliConfiguration` | `Cratis__Chronicle__Mcp__UseCliConfiguration` | Set to `false` to ignore `~/.cratis/config.json` entirely. |
 | `ClientId` / `ClientSecret` | `Cratis__Chronicle__Mcp__ClientId` / `...__ClientSecret` | Client credentials for authentication. Defaults to development credentials if not specified. |
@@ -104,8 +102,13 @@ The server exposes the following tools. Every tool defaults the event store and 
 configured defaults when you do not specify them, so you can ask high-level questions and only
 mention a store or namespace when you need a specific one.
 
-| Tool | Description |
-| ---- | ----------- |
+The tools come in two complementary sets: **operate-side** tools for inspecting and operating a live
+store, and **design-time** tools that turn natural language into Chronicle artifacts grounded in the
+store's real schema. See the [Documentation](./Documentation/index.md) folder for a full guide, and
+[How it works](./Documentation/concepts.md) for the split.
+
+### Operate-side
+
 | Tool | Description |
 | ---- | ----------- |
 | `list_event_stores` | List all event stores on the server. |
@@ -128,6 +131,16 @@ mention a store or namespace when you need a specific one.
 | `resume_job` | Resume a specific stopped job. |
 | `delete_job` | Delete a specific job (transitions to Removing status). |
 
+### Design-time
+
+| Tool | Description |
+| ---- | ----------- |
+| `describe_event_type` | Describe an event type's real schema — every property with its JSON and suggested C# type. The grounding primitive for the others. |
+| `scaffold_read_model` | Generate a reviewable read model + model-bound projection from one or more event types, grounded in their schema. |
+| `audit_unconsumed_event_types` | Report event types nothing reads, plus consumers that reference an event type id that no longer exists. |
+| `generate_event_catalog` | Produce a living data dictionary — every event type, its fields, and its consumers. |
+| `explain_causal_trace` | Read an event source's ordered history with correlation and causation, to narrate what happened and why. |
+
 You can ask it things like:
 
 - List all event stores
@@ -140,6 +153,14 @@ You can ask it things like:
 - Show me job [put job id here] in the [put namespace name here] namespace
 - What steps does job [put job id here] have?
 - Stop / Resume / Delete job [put job id here]
+
+And design-time questions like:
+
+- Show me all the [put concept here] registered (scaffolds a read model + projection)
+- What fields does the [put event type here] event have?
+- What events are we writing that nothing reads?
+- Give me a catalog of our [put area here] events and who reads them
+- Why does [put entity here] show as [put state here]?
 
 ## Local development
 

--- a/Source/Configuration/ChronicleConnectionConfiguration.cs
+++ b/Source/Configuration/ChronicleConnectionConfiguration.cs
@@ -30,19 +30,9 @@ public class ChronicleConnectionConfiguration(IOptions<McpServerOptions> options
     public const string DefaultNamespaceName = "Default";
 
     /// <summary>
-    /// The default management port for the HTTP API and token endpoint.
-    /// </summary>
-    public const int DefaultManagementPort = 8080;
-
-    /// <summary>
     /// Environment variable holding the Chronicle connection string.
     /// </summary>
     public const string ConnectionStringEnvVar = "CHRONICLE_CONNECTION_STRING";
-
-    /// <summary>
-    /// Environment variable holding the management port override.
-    /// </summary>
-    public const string ManagementPortEnvVar = "CHRONICLE_MANAGEMENT_PORT";
 
     const string DefaultConnectionString = "chronicle://localhost:35000/?disableTls=true";
     const string Scheme = "chronicle://";
@@ -82,32 +72,12 @@ public class ChronicleConnectionConfiguration(IOptions<McpServerOptions> options
             else
             {
                 connectionString = !string.IsNullOrWhiteSpace(Context.Server)
-                    ? Context.Server!
+                    ? Context.Server
                     : DefaultConnectionString;
             }
         }
 
         return ComposeCredentials(connectionString);
-    }
-
-    /// <summary>
-    /// Resolves the effective management port.
-    /// </summary>
-    /// <returns>The resolved management port.</returns>
-    public int ResolveManagementPort()
-    {
-        if (_options.ManagementPort.HasValue)
-        {
-            return _options.ManagementPort.Value;
-        }
-
-        var envVar = Environment.GetEnvironmentVariable(ManagementPortEnvVar);
-        if (!string.IsNullOrWhiteSpace(envVar) && int.TryParse(envVar, out var envPort))
-        {
-            return envPort;
-        }
-
-        return Context.ManagementPort ?? DefaultManagementPort;
     }
 
     /// <summary>
@@ -186,13 +156,13 @@ public class ChronicleConnectionConfiguration(IOptions<McpServerOptions> options
         // 2. Cached login token from 'cratis chronicle login'.
         if (!string.IsNullOrWhiteSpace(Context.AccessToken) && IsTokenValid(Context.TokenExpiry))
         {
-            return AppendApiKey(connectionString, Context.AccessToken!);
+            return AppendApiKey(connectionString, Context.AccessToken);
         }
 
         // 3. Service account credentials stored in the CLI context.
         if (!string.IsNullOrWhiteSpace(Context.ClientId) && !string.IsNullOrWhiteSpace(Context.ClientSecret))
         {
-            return InsertCredentials(connectionString, Context.ClientId!, Context.ClientSecret!);
+            return InsertCredentials(connectionString, Context.ClientId, Context.ClientSecret);
         }
 
         // 4. Built-in development credentials for local Chronicle servers.

--- a/Source/Configuration/McpServerOptions.cs
+++ b/Source/Configuration/McpServerOptions.cs
@@ -25,11 +25,6 @@ public class McpServerOptions
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets the management port for the HTTP API and token endpoint.
-    /// </summary>
-    public int? ManagementPort { get; set; }
-
-    /// <summary>
     /// Gets or sets the name of the CLI context to read connection details from.
     /// </summary>
     /// <remarks>

--- a/Source/Connection/ChronicleMcpServiceCollectionExtensions.cs
+++ b/Source/Connection/ChronicleMcpServiceCollectionExtensions.cs
@@ -45,11 +45,10 @@ public static class ChronicleMcpServiceCollectionExtensions
         var correlationIdAccessor = serviceProvider.GetRequiredService<ICorrelationIdAccessor>();
 
         var connectionString = new ChronicleConnectionString(configuration.ResolveConnectionString());
-        var managementPort = configuration.ResolveManagementPort();
 
         // Ownership of the token provider is transferred to the ChronicleConnection, which disposes it when it is disposed.
 #pragma warning disable CA2000
-        var tokenProvider = CreateTokenProvider(connectionString, managementPort, configuration.ContextName, loggerFactory);
+        var tokenProvider = CreateTokenProvider(connectionString, configuration.ContextName, loggerFactory);
 #pragma warning restore CA2000
 
         var connectTimeoutSeconds = int.TryParse(Environment.GetEnvironmentVariable("CHRONICLE_CONNECT_TIMEOUT_SECONDS"), out var timeout) ? timeout : 5;
@@ -73,26 +72,27 @@ public static class ChronicleMcpServiceCollectionExtensions
             skipKeepAlive: false);
     }
 
-    static ITokenProvider? CreateTokenProvider(ChronicleConnectionString connectionString, int managementPort, string contextName, ILoggerFactory loggerFactory) =>
+    static ITokenProvider? CreateTokenProvider(ChronicleConnectionString connectionString, string contextName, ILoggerFactory loggerFactory) =>
         connectionString.AuthenticationMode switch
         {
-            AuthenticationMode.ClientCredentials => CreateCachingTokenProvider(connectionString, managementPort, contextName, loggerFactory),
+            AuthenticationMode.ClientCredentials => CreateCachingTokenProvider(connectionString, contextName, loggerFactory),
             AuthenticationMode.ApiKey when !string.IsNullOrEmpty(connectionString.ApiKey) => new StaticTokenProvider(connectionString.ApiKey),
             _ => null
         };
 
-    static FileSystemCachingTokenProvider CreateCachingTokenProvider(ChronicleConnectionString connectionString, int managementPort, string contextName, ILoggerFactory loggerFactory)
+    static FileSystemCachingTokenProvider CreateCachingTokenProvider(ChronicleConnectionString connectionString, string contextName, ILoggerFactory loggerFactory)
     {
         var cachePath = ChronicleCliConfiguration.GetTokenCachePath($"{contextName}_{connectionString.Username ?? string.Empty}");
         Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
 
         // Ownership of the inner provider is transferred to the FileSystemCachingTokenProvider, which disposes it.
+        // The token endpoint is derived from the connection's server address (host:port/connect/token),
+        // so there is no separate management-port argument as in earlier Chronicle client releases.
 #pragma warning disable CA2000
         var inner = new OAuthTokenProvider(
             connectionString.ServerAddress,
             connectionString.Username ?? string.Empty,
             connectionString.Password ?? string.Empty,
-            managementPort,
             connectionString.DisableTls,
             loggerFactory.CreateLogger<OAuthTokenProvider>());
 #pragma warning restore CA2000

--- a/Source/Tools/Design/CausalEvent.cs
+++ b/Source/Tools/Design/CausalEvent.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A single event in a causal trace, carrying the metadata needed to explain why it happened.
+/// </summary>
+/// <param name="SequenceNumber">The sequence number of the event.</param>
+/// <param name="EventType">The event type id.</param>
+/// <param name="Generation">The event type generation.</param>
+/// <param name="Occurred">When the event occurred.</param>
+/// <param name="CorrelationId">The correlation id grouping this event with the wider flow it belongs to.</param>
+/// <param name="CausedBy">The identity that caused the event, when known.</param>
+/// <param name="Causation">The chain of causes recorded for this event.</param>
+/// <param name="Content">The event payload as JSON.</param>
+public record CausalEvent(
+    ulong SequenceNumber,
+    string EventType,
+    uint Generation,
+    DateTimeOffset? Occurred,
+    Guid CorrelationId,
+    CausedByDescriptor? CausedBy,
+    IReadOnlyList<CausationEntry> Causation,
+    JsonElement? Content);

--- a/Source/Tools/Design/CausalTrace.cs
+++ b/Source/Tools/Design/CausalTrace.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// The ordered causal history of an event source — what happened and why — for turning raw event logs
+/// into a plain-language narrative ("git blame for state").
+/// </summary>
+/// <param name="EventStore">The event store the trace was read from.</param>
+/// <param name="Namespace">The namespace the trace was read from.</param>
+/// <param name="EventSequenceId">The event sequence the trace was read from.</param>
+/// <param name="EventSourceId">The event source the trace is for.</param>
+/// <param name="EventCount">The number of events in the trace.</param>
+/// <param name="Events">The events in sequence order, each with its correlation and causation metadata.</param>
+public record CausalTrace(
+    string EventStore,
+    string Namespace,
+    string EventSequenceId,
+    string EventSourceId,
+    int EventCount,
+    IReadOnlyList<CausalEvent> Events);

--- a/Source/Tools/Design/CausalTraceTools.cs
+++ b/Source/Tools/Design/CausalTraceTools.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Text.Json;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Auditing;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Contracts.EventSequences;
+using Cratis.Chronicle.Mcp.Configuration;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Design-time tool for turning an event source's raw event log into a causal narrative — the ordered
+/// events plus the correlation and causation metadata that explain why each one happened.
+/// </summary>
+[McpServerToolType]
+public static class CausalTraceTools
+{
+    const string DefaultEventSequenceId = "event-log";
+
+    /// <summary>
+    /// Reads the causal history of an event source in sequence order.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="eventSourceId">The event source id to trace.</param>
+    /// <param name="eventSequenceId">The event sequence to read from. Defaults to event-log.</param>
+    /// <param name="eventType">An optional comma-separated event type filter.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace. Defaults to the configured namespace.</param>
+    /// <returns>The causal trace for the event source.</returns>
+    [McpServerTool(Name = "explain_causal_trace")]
+    [Description("Reads the ordered event history for one event source together with each event's correlation id and causation chain, so an agent can narrate what happened and why instead of a support engineer reading raw JSON logs. Read-only. Follow correlation ids to relate an event to the wider flow that produced it.")]
+    public static async Task<CausalTrace> ExplainCausalTrace(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The event source id to trace (e.g. the order id).")] string eventSourceId,
+        [Description("The event sequence to read from. Defaults to event-log.")] string eventSequenceId = DefaultEventSequenceId,
+        [Description("An optional comma-separated event type filter.")] string? eventType = null,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace. Defaults to the configured namespace.")] string? @namespace = null)
+    {
+        var resolvedEventStore = configuration.ResolveEventStore(eventStore);
+        var resolvedNamespace = configuration.ResolveNamespace(@namespace);
+
+        var request = new GetForEventSourceIdAndEventTypesRequest
+        {
+            EventStore = resolvedEventStore,
+            Namespace = resolvedNamespace,
+            EventSequenceId = eventSequenceId,
+            EventSourceId = eventSourceId
+        };
+
+        foreach (var parsed in ParseEventTypes(eventType))
+        {
+            request.EventTypes.Add(parsed);
+        }
+
+        var response = await services.EventSequences.GetForEventSourceIdAndEventTypes(request);
+
+        var events = response.Events
+            .OrderBy(evt => evt.Context.SequenceNumber)
+            .Select(ToCausalEvent)
+            .ToList();
+
+        return new CausalTrace(resolvedEventStore, resolvedNamespace, eventSequenceId, eventSourceId, events.Count, events);
+    }
+
+    static CausalEvent ToCausalEvent(AppendedEvent evt)
+    {
+        var context = evt.Context;
+        return new CausalEvent(
+            context.SequenceNumber,
+            context.EventType?.Id ?? string.Empty,
+            context.EventType?.Generation ?? 0,
+            context.Occurred,
+            context.CorrelationId,
+            ToCausedBy(context.CausedBy),
+            (context.Causation ?? []).Select(ToCausationEntry).ToList(),
+            TryParse(evt.Content));
+    }
+
+    static CausedByDescriptor? ToCausedBy(Cratis.Chronicle.Contracts.Identities.Identity? identity) =>
+        identity is null
+            ? null
+            : new CausedByDescriptor(identity.Subject ?? string.Empty, identity.Name ?? string.Empty, identity.UserName ?? string.Empty);
+
+    static CausationEntry ToCausationEntry(Causation causation) =>
+        new(
+            causation.Type ?? string.Empty,
+            causation.Occurred,
+            causation.Properties is null ? new Dictionary<string, string>() : new Dictionary<string, string>(causation.Properties));
+
+    static IEnumerable<EventType> ParseEventTypes(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return [];
+        }
+
+        return input
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(entry =>
+            {
+                var parts = entry.Split('+');
+                return new EventType
+                {
+                    Id = parts[0],
+                    Generation = parts.Length > 1 && uint.TryParse(parts[1], out var generation) ? generation : 1u
+                };
+            });
+    }
+
+    static JsonElement? TryParse(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<JsonElement>(content);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/Source/Tools/Design/CausationEntry.cs
+++ b/Source/Tools/Design/CausationEntry.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A single recorded cause for an event.
+/// </summary>
+/// <param name="Type">The kind of cause (e.g. a command or an upstream event).</param>
+/// <param name="Occurred">When the cause occurred.</param>
+/// <param name="Properties">The details of the cause.</param>
+public record CausationEntry(string Type, DateTimeOffset? Occurred, IReadOnlyDictionary<string, string> Properties);

--- a/Source/Tools/Design/CausedByDescriptor.cs
+++ b/Source/Tools/Design/CausedByDescriptor.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// The identity that caused an event.
+/// </summary>
+/// <param name="Subject">The subject identifier.</param>
+/// <param name="Name">The display name.</param>
+/// <param name="UserName">The user name.</param>
+public record CausedByDescriptor(string Subject, string Name, string UserName);

--- a/Source/Tools/Design/DanglingEventTypeReference.cs
+++ b/Source/Tools/Design/DanglingEventTypeReference.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A consumer that references an event type id which is not present in the store's event type registry.
+/// </summary>
+/// <param name="EventTypeId">The referenced-but-missing event type id.</param>
+/// <param name="ConsumerType">The kind of consumer holding the reference (e.g. Projection, Reducer, Reactor).</param>
+/// <param name="ConsumerId">The identifier of the consumer.</param>
+public record DanglingEventTypeReference(string EventTypeId, string ConsumerType, string ConsumerId);

--- a/Source/Tools/Design/DesignIntrospection.cs
+++ b/Source/Tools/Design/DesignIntrospection.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Contracts.Projections;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Shared introspection helpers for the design-time tools. Everything here reads the store's registered
+/// schema so suggestions are grounded in what actually exists rather than guessed.
+/// </summary>
+public static class DesignIntrospection
+{
+    /// <summary>
+    /// Resolves the registration for an event type by name, picking a specific generation or the latest one.
+    /// </summary>
+    /// <param name="registrations">The registrations returned from the store.</param>
+    /// <param name="name">The event type id/name to resolve (case-insensitive).</param>
+    /// <param name="generation">The optional specific generation to resolve; the highest generation is used when null.</param>
+    /// <returns>The matching <see cref="EventTypeRegistration"/>, or null when no event type matches.</returns>
+    public static EventTypeRegistration? ResolveRegistration(IEnumerable<EventTypeRegistration> registrations, string name, uint? generation = null)
+    {
+        var matches = registrations
+            .Where(registration => string.Equals(registration.Type.Id, name, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count == 0)
+        {
+            return null;
+        }
+
+        return generation.HasValue
+            ? matches.FirstOrDefault(registration => registration.Type.Generation == generation.Value)
+            : matches.OrderByDescending(registration => registration.Type.Generation).First();
+    }
+
+    /// <summary>
+    /// Collects every event type id consumed by a projection, walking nested and child projections.
+    /// </summary>
+    /// <param name="projection">The projection definition to inspect.</param>
+    /// <returns>The distinct set of event type ids the projection reads from.</returns>
+    public static IReadOnlySet<string> CollectConsumedEventTypeIds(ProjectionDefinition projection)
+    {
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        CollectFromLevel(projection.From, projection.Join, projection.RemovedWith, projection.RemovedWithJoin, projection.FromEventProperty, projection.Children, projection.Nested, ids);
+        return ids;
+    }
+
+    static void CollectFromLevel(
+        IDictionary<EventType, FromDefinition> from,
+        IDictionary<EventType, JoinDefinition> join,
+        IDictionary<EventType, RemovedWithDefinition> removedWith,
+        IDictionary<EventType, RemovedWithJoinDefinition> removedWithJoin,
+        FromEventPropertyDefinition? fromEventProperty,
+        IDictionary<string, ChildrenDefinition> children,
+        IDictionary<string, ChildrenDefinition> nested,
+        HashSet<string> ids)
+    {
+        AddEventTypeIds(from?.Keys, ids);
+        AddEventTypeIds(join?.Keys, ids);
+        AddEventTypeIds(removedWith?.Keys, ids);
+        AddEventTypeIds(removedWithJoin?.Keys, ids);
+
+        if (fromEventProperty?.Event is { } propertyEvent && !string.IsNullOrEmpty(propertyEvent.Id))
+        {
+            ids.Add(propertyEvent.Id);
+        }
+
+        foreach (var child in EnumerateChildren(children).Concat(EnumerateChildren(nested)))
+        {
+            CollectFromLevel(child.From, child.Join, child.RemovedWith, child.RemovedWithJoin, child.FromEventProperty, child.Children, child.Nested, ids);
+        }
+    }
+
+    static IEnumerable<ChildrenDefinition> EnumerateChildren(IDictionary<string, ChildrenDefinition>? children) =>
+        children?.Values ?? [];
+
+    static void AddEventTypeIds(IEnumerable<EventType>? eventTypes, HashSet<string> ids)
+    {
+        foreach (var eventType in eventTypes ?? [])
+        {
+            if (!string.IsNullOrEmpty(eventType.Id))
+            {
+                ids.Add(eventType.Id);
+            }
+        }
+    }
+}

--- a/Source/Tools/Design/EventCatalogConsumer.cs
+++ b/Source/Tools/Design/EventCatalogConsumer.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A consumer of an event type in the catalog.
+/// </summary>
+/// <param name="Type">The kind of consumer (e.g. Projection, Reducer, Reactor).</param>
+/// <param name="Id">The identifier of the consumer.</param>
+/// <param name="ReadModel">The read model the consumer builds, when it builds one; otherwise null.</param>
+public record EventCatalogConsumer(string Type, string Id, string? ReadModel);

--- a/Source/Tools/Design/EventCatalogEntry.cs
+++ b/Source/Tools/Design/EventCatalogEntry.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A single entry in the domain event catalog — one event type, its fields, and everything that consumes it.
+/// </summary>
+/// <param name="Id">The event type id — the ubiquitous-language term for this fact.</param>
+/// <param name="Generation">The current generation of the event type.</param>
+/// <param name="Tombstone">Whether the event type is a tombstone.</param>
+/// <param name="Owner">The owner of the event type (e.g. Client or Chronicle).</param>
+/// <param name="Source">The source of the registration (e.g. Code).</param>
+/// <param name="ForeignEventStore">The originating event store when received from another store, otherwise null.</param>
+/// <param name="Properties">The properties declared on the event type schema.</param>
+/// <param name="Consumers">Everything that reads this event type (projections, reducers, reactors).</param>
+public record EventCatalogEntry(
+    string Id,
+    uint Generation,
+    bool Tombstone,
+    string Owner,
+    string Source,
+    string? ForeignEventStore,
+    IReadOnlyList<EventSchemaProperty> Properties,
+    IReadOnlyList<EventCatalogConsumer> Consumers);

--- a/Source/Tools/Design/EventCatalogTools.cs
+++ b/Source/Tools/Design/EventCatalogTools.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Mcp.Configuration;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Design-time tools for producing a living data dictionary from the event store — every event type,
+/// its fields, and which projections, reducers, and reactors consume it. Event names are the ubiquitous
+/// language of an event-sourced system; this keeps that language documented and current from the store.
+/// </summary>
+[McpServerToolType]
+public static class EventCatalogTools
+{
+    /// <summary>
+    /// Generates a catalog of every registered event type, its fields, and its consumers.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace to resolve observers in. Defaults to the configured namespace.</param>
+    /// <param name="eventType">An optional single event type id to scope the catalog to.</param>
+    /// <returns>A catalog entry per event type.</returns>
+    [McpServerTool(Name = "generate_event_catalog")]
+    [Description("Produces a living data dictionary from the event store: every event type with its fields (from the registered schema) and every projection, reducer, and reactor that consumes it. Ideal onboarding material and grounding for modeling questions. Read-only introspection. Optionally scope to a single event type.")]
+    public static async Task<IEnumerable<EventCatalogEntry>> GenerateEventCatalog(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace to resolve observers in. Defaults to the configured namespace.")] string? @namespace = null,
+        [Description("An optional single event type id to scope the catalog to.")] string? eventType = null)
+    {
+        var resolvedEventStore = configuration.ResolveEventStore(eventStore);
+        var resolvedNamespace = configuration.ResolveNamespace(@namespace);
+
+        var registrations = (await services.EventTypes.GetAllRegistrations(new GetAllEventTypesRequest { EventStore = resolvedEventStore })).ToList();
+        var projections = (await services.Projections.GetAllDefinitions(new GetAllDefinitionsRequest { EventStore = resolvedEventStore })).ToList();
+        var observers = (await services.Observers.GetObservers(new AllObserversRequest { EventStore = resolvedEventStore, Namespace = resolvedNamespace })).ToList();
+        var readModels = (await services.ReadModels.GetDefinitions(new GetDefinitionsRequest { EventStore = resolvedEventStore })).ReadModels;
+
+        var consumersByEventType = BuildConsumerIndex(projections, observers, readModels);
+
+        return registrations
+            .GroupBy(registration => registration.Type.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.OrderByDescending(registration => registration.Type.Generation).First())
+            .Where(registration => string.IsNullOrWhiteSpace(eventType) || string.Equals(registration.Type.Id, eventType, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(registration => registration.Type.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(registration => new EventCatalogEntry(
+                registration.Type.Id,
+                registration.Type.Generation,
+                registration.Type.Tombstone,
+                registration.Owner.ToString(),
+                registration.Source.ToString(),
+                string.IsNullOrEmpty(registration.EventStore) ? null : registration.EventStore,
+                EventSchemaParser.Parse(registration.Schema),
+                Consumers(consumersByEventType, registration.Type.Id)))
+            .ToList();
+    }
+
+    static List<EventCatalogConsumer> Consumers(Dictionary<string, List<EventCatalogConsumer>> index, string eventTypeId) =>
+        index.TryGetValue(eventTypeId, out var consumers) ? consumers : [];
+
+    static Dictionary<string, List<EventCatalogConsumer>> BuildConsumerIndex(
+        IEnumerable<ProjectionDefinition> projections,
+        IEnumerable<ObserverInformation> observers,
+        IEnumerable<ReadModelDefinition> readModels)
+    {
+        var readModelByObserverId = readModels
+            .Where(readModel => !string.IsNullOrEmpty(readModel.ObserverIdentifier))
+            .GroupBy(readModel => readModel.ObserverIdentifier, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => ReadModelName(group.First()), StringComparer.Ordinal);
+
+        var index = new Dictionary<string, List<EventCatalogConsumer>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var projection in projections)
+        {
+            var consumer = new EventCatalogConsumer(nameof(ObserverType.Projection), projection.Identifier, string.IsNullOrWhiteSpace(projection.ReadModel) ? null : projection.ReadModel);
+            foreach (var eventTypeId in DesignIntrospection.CollectConsumedEventTypeIds(projection))
+            {
+                Add(index, eventTypeId, consumer);
+            }
+        }
+
+        foreach (var observer in observers.Where(observer => observer.Type != ObserverType.Projection))
+        {
+            var readModel = readModelByObserverId.TryGetValue(observer.Id, out var name) ? name : null;
+            var consumer = new EventCatalogConsumer(observer.Type.ToString(), observer.Id, readModel);
+            foreach (var eventTypeId in (observer.EventTypes ?? []).Select(eventType => eventType.Id).Where(id => !string.IsNullOrEmpty(id)))
+            {
+                Add(index, eventTypeId, consumer);
+            }
+        }
+
+        return index;
+    }
+
+    static string? ReadModelName(ReadModelDefinition readModel)
+    {
+        if (!string.IsNullOrWhiteSpace(readModel.DisplayName))
+        {
+            return readModel.DisplayName;
+        }
+
+        return string.IsNullOrWhiteSpace(readModel.ContainerName) ? null : readModel.ContainerName;
+    }
+
+    static void Add(Dictionary<string, List<EventCatalogConsumer>> index, string eventTypeId, EventCatalogConsumer consumer)
+    {
+        if (!index.TryGetValue(eventTypeId, out var consumers))
+        {
+            consumers = [];
+            index[eventTypeId] = consumers;
+        }
+
+        if (!consumers.Exists(existing => existing.Type == consumer.Type && existing.Id == consumer.Id))
+        {
+            consumers.Add(consumer);
+        }
+    }
+}

--- a/Source/Tools/Design/EventSchemaParser.cs
+++ b/Source/Tools/Design/EventSchemaParser.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Parses the JSON schema carried on a Chronicle event type registration into a flat list of
+/// properties, so design-time tools can ground their suggestions in the event's real shape.
+/// </summary>
+public static class EventSchemaParser
+{
+    /// <summary>
+    /// Parses the top-level properties of an event type's JSON schema.
+    /// </summary>
+    /// <param name="schema">The JSON schema string from an event type registration.</param>
+    /// <returns>The properties declared on the schema, or an empty collection when the schema is missing or unparseable.</returns>
+    public static IReadOnlyList<EventSchemaProperty> Parse(string? schema)
+    {
+        if (string.IsNullOrWhiteSpace(schema))
+        {
+            return [];
+        }
+
+        JsonElement root;
+        try
+        {
+            using var document = JsonDocument.Parse(schema);
+            root = document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        if (root.ValueKind != JsonValueKind.Object || !root.TryGetProperty("properties", out var properties) || properties.ValueKind != JsonValueKind.Object)
+        {
+            return [];
+        }
+
+        var required = ReadRequired(root);
+
+        return properties.EnumerateObject()
+            .Select(property => ToSchemaProperty(property.Name, property.Value, required.Contains(property.Name)))
+            .ToList();
+    }
+
+    static HashSet<string> ReadRequired(JsonElement root)
+    {
+        if (!root.TryGetProperty("required", out var required) || required.ValueKind != JsonValueKind.Array)
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+
+        return required.EnumerateArray()
+            .Where(entry => entry.ValueKind == JsonValueKind.String)
+            .Select(entry => entry.GetString()!)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    static EventSchemaProperty ToSchemaProperty(string name, JsonElement definition, bool required)
+    {
+        var jsonType = ReadType(definition);
+        var format = ReadString(definition, "format");
+        var description = ReadString(definition, "description");
+        var clrType = ToClrType(jsonType, format, definition);
+
+        return new EventSchemaProperty(name, jsonType, clrType, format, required, description);
+    }
+
+    static string ReadType(JsonElement definition)
+    {
+        if (definition.TryGetProperty("type", out var type))
+        {
+            return type.ValueKind switch
+            {
+                JsonValueKind.String => type.GetString() ?? "object",
+                JsonValueKind.Array => type.EnumerateArray()
+                    .Where(entry => entry.ValueKind == JsonValueKind.String)
+                    .Select(entry => entry.GetString())
+                    .FirstOrDefault(entry => !string.Equals(entry, "null", StringComparison.Ordinal)) ?? "object",
+                _ => "object"
+            };
+        }
+
+        return "object";
+    }
+
+    static string ToClrType(string jsonType, string? format, JsonElement definition) =>
+        (jsonType, format) switch
+        {
+            (_, "guid") => "Guid",
+            (_, "uuid") => "Guid",
+            (_, "date-time") => "DateTimeOffset",
+            (_, "date") => "DateOnly",
+            (_, "time") => "TimeOnly",
+            (_, "int32") => "int",
+            (_, "int64") => "long",
+            ("string", _) => "string",
+            ("integer", _) => "int",
+            ("number", _) => "double",
+            ("boolean", _) => "bool",
+            ("array", _) => $"IEnumerable<{ElementClrType(definition)}>",
+            _ => ReferenceTypeName(definition)
+        };
+
+    static string ElementClrType(JsonElement definition)
+    {
+        if (!definition.TryGetProperty("items", out var items) || items.ValueKind != JsonValueKind.Object)
+        {
+            return "object";
+        }
+
+        var itemType = ReadType(items);
+        var itemFormat = ReadString(items, "format");
+        return ToClrType(itemType, itemFormat, items);
+    }
+
+    static string ReferenceTypeName(JsonElement definition)
+    {
+        var reference = ReadString(definition, "$ref");
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            return "object";
+        }
+
+        var lastSegment = reference.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+        return string.IsNullOrWhiteSpace(lastSegment) ? "object" : lastSegment;
+    }
+
+    static string? ReadString(JsonElement definition, string propertyName) =>
+        definition.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/Source/Tools/Design/EventSchemaProperty.cs
+++ b/Source/Tools/Design/EventSchemaProperty.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A single property discovered on an event type's JSON schema, grounded in what the store actually
+/// has registered rather than guessed.
+/// </summary>
+/// <param name="Name">The property name as it appears on the event.</param>
+/// <param name="JsonType">The JSON schema type (e.g. string, integer, number, boolean, array, object).</param>
+/// <param name="ClrType">The suggested C# type for the property, derived from the JSON type and format.</param>
+/// <param name="Format">The JSON schema format when present (e.g. date-time, guid, int32), otherwise null.</param>
+/// <param name="Required">Whether the property is listed as required on the schema.</param>
+/// <param name="Description">The property description from the schema when present, otherwise null.</param>
+public record EventSchemaProperty(
+    string Name,
+    string JsonType,
+    string ClrType,
+    string? Format,
+    bool Required,
+    string? Description);

--- a/Source/Tools/Design/EventTypeAuditResult.cs
+++ b/Source/Tools/Design/EventTypeAuditResult.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// The result of auditing an event store's event types against everything that consumes them.
+/// </summary>
+/// <param name="EventStore">The event store that was audited.</param>
+/// <param name="Namespace">The namespace the observers were audited in.</param>
+/// <param name="TotalEventTypes">The number of registered event types considered.</param>
+/// <param name="Unconsumed">Event types that no projection, reducer, or reactor reads — data written that nothing consumes.</param>
+/// <param name="DanglingReferences">Consumers that reference an event type id no longer present in the registry.</param>
+public record EventTypeAuditResult(
+    string EventStore,
+    string Namespace,
+    int TotalEventTypes,
+    IReadOnlyList<UnconsumedEventType> Unconsumed,
+    IReadOnlyList<DanglingEventTypeReference> DanglingReferences);

--- a/Source/Tools/Design/EventTypeAuditTools.cs
+++ b/Source/Tools/Design/EventTypeAuditTools.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Mcp.Configuration;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Design-time tools for auditing event types against what consumes them, surfacing silent data debt:
+/// events written that nothing reads, and consumers pointing at event types that no longer exist.
+/// </summary>
+[McpServerToolType]
+public static class EventTypeAuditTools
+{
+    /// <summary>
+    /// Audits registered event types against every projection, reducer, and reactor that consumes them.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace to resolve observers in. Defaults to the configured namespace.</param>
+    /// <returns>The audit result listing unconsumed event types and dangling references.</returns>
+    [McpServerTool(Name = "audit_unconsumed_event_types")]
+    [Description("Cross-references every registered event type against all projections, reducers, and reactors, and reports the event types that nothing consumes (data being written that no read model or reactor reads) plus the inverse: consumers that reference an event type id which no longer exists. Use as a periodic data-debt health check. Read-only introspection — grounded entirely in the store's registry and observer definitions.")]
+    public static async Task<EventTypeAuditResult> AuditUnconsumedEventTypes(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace to resolve observers in. Defaults to the configured namespace.")] string? @namespace = null)
+    {
+        var resolvedEventStore = configuration.ResolveEventStore(eventStore);
+        var resolvedNamespace = configuration.ResolveNamespace(@namespace);
+
+        var registrations = (await services.EventTypes.GetAllRegistrations(new GetAllEventTypesRequest { EventStore = resolvedEventStore })).ToList();
+        var projections = (await services.Projections.GetAllDefinitions(new GetAllDefinitionsRequest { EventStore = resolvedEventStore })).ToList();
+        var observers = (await services.Observers.GetObservers(new AllObserversRequest { EventStore = resolvedEventStore, Namespace = resolvedNamespace })).ToList();
+
+        var references = CollectReferences(projections, observers);
+        var consumedIds = references.Select(reference => reference.EventTypeId).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var registeredIds = registrations
+            .GroupBy(registration => registration.Type.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.OrderByDescending(registration => registration.Type.Generation).First())
+            .ToList();
+
+        var unconsumed = registeredIds
+            .Where(registration => !consumedIds.Contains(registration.Type.Id))
+            .OrderBy(registration => registration.Type.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(registration => new UnconsumedEventType(
+                registration.Type.Id,
+                registration.Type.Generation,
+                registration.Owner.ToString(),
+                registration.Type.Tombstone))
+            .ToList();
+
+        var registeredIdSet = registeredIds.Select(registration => registration.Type.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var dangling = references
+            .Where(reference => !registeredIdSet.Contains(reference.EventTypeId))
+            .Distinct()
+            .OrderBy(reference => reference.EventTypeId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new EventTypeAuditResult(resolvedEventStore, resolvedNamespace, registeredIdSet.Count, unconsumed, dangling);
+    }
+
+    static List<DanglingEventTypeReference> CollectReferences(IEnumerable<ProjectionDefinition> projections, IEnumerable<ObserverInformation> observers)
+    {
+        var references = new List<DanglingEventTypeReference>();
+
+        foreach (var projection in projections)
+        {
+            references.AddRange(DesignIntrospection.CollectConsumedEventTypeIds(projection)
+                .Select(id => new DanglingEventTypeReference(id, nameof(ObserverType.Projection), projection.Identifier)));
+        }
+
+        foreach (var observer in observers)
+        {
+            references.AddRange((observer.EventTypes ?? [])
+                .Where(eventType => !string.IsNullOrEmpty(eventType.Id))
+                .Select(eventType => new DanglingEventTypeReference(eventType.Id, observer.Type.ToString(), observer.Id)));
+        }
+
+        return references;
+    }
+}

--- a/Source/Tools/Design/EventTypeSchemaDescriptor.cs
+++ b/Source/Tools/Design/EventTypeSchemaDescriptor.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A grounded description of an event type's shape, taken directly from the schema registered in the store.
+/// </summary>
+/// <param name="Id">The unique identifier of the event type.</param>
+/// <param name="Generation">The generation the schema describes.</param>
+/// <param name="Tombstone">Whether the event type represents a tombstone.</param>
+/// <param name="Owner">The owner of the event type (e.g. Client or Chronicle).</param>
+/// <param name="Source">The source of the event type registration (e.g. Code).</param>
+/// <param name="ForeignEventStore">The originating event store when the type is received from another store, otherwise null.</param>
+/// <param name="Properties">The properties declared on the event type schema.</param>
+public record EventTypeSchemaDescriptor(
+    string Id,
+    uint Generation,
+    bool Tombstone,
+    string Owner,
+    string Source,
+    string? ForeignEventStore,
+    IReadOnlyList<EventSchemaProperty> Properties);

--- a/Source/Tools/Design/ExistingProjectionMatch.cs
+++ b/Source/Tools/Design/ExistingProjectionMatch.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// An existing projection that overlaps with a scaffold request, surfaced to avoid duplicating work.
+/// </summary>
+/// <param name="ProjectionIdentifier">The identifier of the existing projection.</param>
+/// <param name="ReadModel">The read model the existing projection targets.</param>
+/// <param name="OverlappingEventTypes">The event types the existing projection shares with the request.</param>
+public record ExistingProjectionMatch(string ProjectionIdentifier, string ReadModel, IReadOnlyList<string> OverlappingEventTypes);

--- a/Source/Tools/Design/ReadModelDesignTools.cs
+++ b/Source/Tools/Design/ReadModelDesignTools.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Mcp.Configuration;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// The flagship design-time capability: turn a set of event types (which an agent resolves from a plain
+/// natural-language request) into a reviewable read model + model-bound projection, grounded in the
+/// events' real schema. The output is always a proposal to review, never a silent write.
+/// </summary>
+[McpServerToolType]
+public static class ReadModelDesignTools
+{
+    /// <summary>
+    /// Scaffolds a read model and its model-bound projection from one or more registered event types.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="readModelName">The name of the read model to generate.</param>
+    /// <param name="eventTypes">A comma-separated list of event type ids to project from.</param>
+    /// <param name="codeNamespace">The C# namespace to generate the read model into.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <returns>The scaffold, including grounded fields, existing-projection warnings, and generated code.</returns>
+    [McpServerTool(Name = "scaffold_read_model")]
+    [Description("Generates a reviewable read model + model-bound projection from one or more event types, grounded in the events' real schema (field names and types come from the store, never guesses). Resolve the event types from the user's request first — with list_event_types, describe_event_type, or generate_event_catalog — then pass them here. Surfaces existing projections that already read these events so a duplicate is not created. When none of the requested event types are registered it returns no code and says so rather than fabricating a shape.")]
+    public static async Task<ReadModelScaffold> ScaffoldReadModel(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The name of the read model to generate (e.g. Users).")] string readModelName,
+        [Description("A comma-separated list of event type ids to project from (e.g. UserRegistered,UserEmailVerified).")] string eventTypes,
+        [Description("The C# namespace to generate the read model into. Defaults to ReadModels.")] string codeNamespace = "ReadModels",
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null)
+    {
+        var resolvedEventStore = configuration.ResolveEventStore(eventStore);
+        var requested = SplitNames(eventTypes);
+        var notes = new List<string>();
+
+        if (requested.Count == 0)
+        {
+            notes.Add("No event types were provided. Pass one or more event type ids to ground the read model.");
+            return new ReadModelScaffold(readModelName, codeNamespace, null, [], [], [], [], notes);
+        }
+
+        var registrations = (await services.EventTypes.GetAllRegistrations(new GetAllEventTypesRequest { EventStore = resolvedEventStore })).ToList();
+
+        var resolved = new List<EventTypeRegistration>();
+        var unresolved = new List<string>();
+        foreach (var name in requested)
+        {
+            var registration = DesignIntrospection.ResolveRegistration(registrations, name);
+            if (registration is null)
+            {
+                unresolved.Add(name);
+            }
+            else
+            {
+                resolved.Add(registration);
+            }
+        }
+
+        if (resolved.Count == 0)
+        {
+            notes.Add("None of the requested event types are registered in this event store, so a read model cannot be grounded. Verify the names with list_event_types or generate_event_catalog.");
+            return new ReadModelScaffold(readModelName, codeNamespace, null, [], [], unresolved, [], notes);
+        }
+
+        if (unresolved.Count > 0)
+        {
+            notes.Add($"Skipped unregistered event types: {string.Join(", ", unresolved)}.");
+        }
+
+        var resolvedIds = resolved.ConvertAll(registration => registration.Type.Id);
+        var fields = ReadModelScaffolder.CollectFields(resolved, notes);
+
+        if (fields.Count == 0)
+        {
+            notes.Add("The resolved event types carry no schema properties beyond identity, so the read model has only its key. Add fields once the events carry data.");
+        }
+
+        var existing = await FindExistingProjections(services, resolvedEventStore, readModelName, resolvedIds);
+        if (existing.Count > 0)
+        {
+            notes.Add("One or more existing projections already read these events or target this read model. Review them before applying the scaffold to avoid a duplicate.");
+        }
+
+        var code = ReadModelScaffolder.Generate(readModelName, codeNamespace, resolvedIds, fields);
+
+        return new ReadModelScaffold(readModelName, codeNamespace, code, fields, resolvedIds, unresolved, existing, notes);
+    }
+
+    static async Task<IReadOnlyList<ExistingProjectionMatch>> FindExistingProjections(IServices services, string eventStore, string readModelName, IReadOnlyList<string> resolvedIds)
+    {
+        var projections = await services.Projections.GetAllDefinitions(new GetAllDefinitionsRequest { EventStore = eventStore });
+        var resolvedIdSet = resolvedIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return projections
+            .Select(projection => (projection, overlap: DesignIntrospection.CollectConsumedEventTypeIds(projection).Where(resolvedIdSet.Contains).Order(StringComparer.OrdinalIgnoreCase).ToList()))
+            .Where(candidate => candidate.overlap.Count > 0 || string.Equals(candidate.projection.ReadModel, readModelName, StringComparison.OrdinalIgnoreCase))
+            .Select(candidate => new ExistingProjectionMatch(candidate.projection.Identifier, candidate.projection.ReadModel, candidate.overlap))
+            .ToList();
+    }
+
+    static List<string> SplitNames(string input) =>
+        string.IsNullOrWhiteSpace(input)
+            ? []
+            : input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+}

--- a/Source/Tools/Design/ReadModelScaffold.cs
+++ b/Source/Tools/Design/ReadModelScaffold.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A proposed read model + model-bound projection, scaffolded from the real schema of the chosen event
+/// types. Always a proposal to review and apply — never a silent write into a codebase.
+/// </summary>
+/// <param name="ReadModelName">The name of the proposed read model.</param>
+/// <param name="Namespace">The C# namespace the scaffold was generated into.</param>
+/// <param name="Code">The generated C# code for the read model and its model-bound projection, or null when it could not be grounded.</param>
+/// <param name="Fields">The fields chosen for the read model, each traced back to the event it came from.</param>
+/// <param name="ResolvedEventTypes">The requested event types that were found in the store and used.</param>
+/// <param name="UnresolvedEventTypes">The requested event types that are not registered — grounding failed for these.</param>
+/// <param name="ExistingProjections">Existing projections that already read these events or target this read model, so a duplicate is not created blindly.</param>
+/// <param name="Notes">Human-readable notes and caveats about the scaffold.</param>
+public record ReadModelScaffold(
+    string ReadModelName,
+    string Namespace,
+    string? Code,
+    IReadOnlyList<ScaffoldedField> Fields,
+    IReadOnlyList<string> ResolvedEventTypes,
+    IReadOnlyList<string> UnresolvedEventTypes,
+    IReadOnlyList<ExistingProjectionMatch> ExistingProjections,
+    IReadOnlyList<string> Notes);

--- a/Source/Tools/Design/ReadModelScaffolder.cs
+++ b/Source/Tools/Design/ReadModelScaffolder.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Turns resolved event type schemas into a model-bound read model + projection scaffold. Pure code
+/// generation grounded in the fields the events actually carry — no store access happens here.
+/// </summary>
+public static class ReadModelScaffolder
+{
+    /// <summary>
+    /// Collects the read model fields from the resolved event type registrations, de-duplicating by name.
+    /// </summary>
+    /// <param name="registrations">The resolved event type registrations to draw fields from.</param>
+    /// <param name="notes">A collection that receives notes about type conflicts or skipped fields.</param>
+    /// <returns>The chosen fields, in first-seen order.</returns>
+    public static IReadOnlyList<ScaffoldedField> CollectFields(IReadOnlyList<EventTypeRegistration> registrations, ICollection<string> notes)
+    {
+        var fields = new List<ScaffoldedField>();
+        var seen = new Dictionary<string, ScaffoldedField>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var registration in registrations)
+        {
+            foreach (var property in EventSchemaParser.Parse(registration.Schema))
+            {
+                var name = PascalCase(property.Name);
+                if (string.Equals(name, "Id", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (seen.TryGetValue(name, out var existing))
+                {
+                    if (!string.Equals(existing.ClrType, property.ClrType, StringComparison.Ordinal))
+                    {
+                        notes.Add($"Property '{name}' appears as {existing.ClrType} (from {existing.SourceEventType}) and {property.ClrType} (from {registration.Type.Id}); kept the first. Review the type.");
+                    }
+
+                    continue;
+                }
+
+                var field = new ScaffoldedField(name, property.ClrType, registration.Type.Id);
+                seen[name] = field;
+                fields.Add(field);
+            }
+        }
+
+        return fields;
+    }
+
+    /// <summary>
+    /// Generates the C# source for a model-bound read model and its projection.
+    /// </summary>
+    /// <param name="readModelName">The read model name.</param>
+    /// <param name="namespaceName">The C# namespace to place the read model in.</param>
+    /// <param name="eventTypeIds">The event type ids to wire up via <c>[FromEvent&lt;T&gt;]</c>.</param>
+    /// <param name="fields">The read model fields.</param>
+    /// <returns>The generated C# source.</returns>
+    public static string Generate(string readModelName, string namespaceName, IReadOnlyList<string> eventTypeIds, IReadOnlyList<ScaffoldedField> fields)
+    {
+        var parameterList = new List<string> { "    Guid Id" };
+        parameterList.AddRange(fields.Select(field => $"    {field.ClrType} {field.Name}"));
+
+        var lines = new List<string>
+        {
+            "// Copyright (c) Cratis. All rights reserved.",
+            "// Licensed under the MIT license. See LICENSE file in the project root for full license information.",
+            string.Empty,
+            "using MongoDB.Driver;",
+            string.Empty,
+            $"namespace {namespaceName};",
+            string.Empty,
+            "/// <summary>",
+            $"/// {readModelName} read model, scaffolded from {string.Join(", ", eventTypeIds)}.",
+            "/// Review the field selection and replace the Guid identity with a strongly-typed EventSourceId concept before use.",
+            "/// </summary>",
+            "[ReadModel]"
+        };
+
+        lines.AddRange(eventTypeIds.Select(id => $"[FromEvent<{id}>]"));
+        lines.Add($"public record {readModelName}(");
+        lines.Add(string.Join(",\n", parameterList) + ")");
+        lines.Add("{");
+        lines.Add("    /// <summary>");
+        lines.Add($"    /// Queries all {readModelName} instances.");
+        lines.Add("    /// </summary>");
+        lines.Add("    /// <param name=\"collection\">The read model collection.</param>");
+        lines.Add($"    /// <returns>All {readModelName} instances.</returns>");
+        lines.Add($"    public static IQueryable<{readModelName}> All{readModelName}(IMongoCollection<{readModelName}> collection) =>");
+        lines.Add("        collection.AsQueryable();");
+        lines.Add("}");
+
+        return string.Join('\n', lines) + "\n";
+    }
+
+    static string PascalCase(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        return char.ToUpper(value[0], CultureInfo.InvariantCulture) + value[1..];
+    }
+}

--- a/Source/Tools/Design/ScaffoldedField.cs
+++ b/Source/Tools/Design/ScaffoldedField.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A single field chosen for a scaffolded read model, grounded in an event's real schema.
+/// </summary>
+/// <param name="Name">The read model property name.</param>
+/// <param name="ClrType">The suggested C# type.</param>
+/// <param name="SourceEventType">The event type the field was taken from.</param>
+public record ScaffoldedField(string Name, string ClrType, string SourceEventType);

--- a/Source/Tools/Design/SchemaTools.cs
+++ b/Source/Tools/Design/SchemaTools.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Mcp.Configuration;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Design-time tools for inspecting the real shape (schema) of registered event types. This is the
+/// grounding primitive the other design-time tools build on: field names and types come from the
+/// store, never from a guess.
+/// </summary>
+[McpServerToolType]
+public static class SchemaTools
+{
+    /// <summary>
+    /// Describes the schema of a registered event type, listing its properties with their types.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="eventType">The event type id/name to describe.</param>
+    /// <param name="generation">The optional specific generation; the latest is used when omitted.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <returns>The event type's schema, or null when no matching event type is registered.</returns>
+    [McpServerTool(Name = "describe_event_type")]
+    [Description("Describes a registered event type's real schema — every property with its JSON type and a suggested C# type — read from the store's event type registry. Use this to ground any generated projection, read model, or spec in the event's actual fields instead of guessing. Returns null when the event type is not registered.")]
+    public static async Task<EventTypeSchemaDescriptor?> DescribeEventType(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The event type id/name to describe (e.g. UserRegistered).")] string eventType,
+        [Description("The optional specific generation to describe. The latest generation is used when omitted.")] uint? generation = null,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null)
+    {
+        var registrations = await services.EventTypes.GetAllRegistrations(new GetAllEventTypesRequest
+        {
+            EventStore = configuration.ResolveEventStore(eventStore)
+        });
+
+        var registration = DesignIntrospection.ResolveRegistration(registrations, eventType, generation);
+        if (registration is null)
+        {
+            return null;
+        }
+
+        return new EventTypeSchemaDescriptor(
+            registration.Type.Id,
+            registration.Type.Generation,
+            registration.Type.Tombstone,
+            registration.Owner.ToString(),
+            registration.Source.ToString(),
+            string.IsNullOrEmpty(registration.EventStore) ? null : registration.EventStore,
+            EventSchemaParser.Parse(registration.Schema));
+    }
+}

--- a/Source/Tools/Design/UnconsumedEventType.cs
+++ b/Source/Tools/Design/UnconsumedEventType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// An event type that is registered but consumed by nothing.
+/// </summary>
+/// <param name="Id">The event type id.</param>
+/// <param name="Generation">The current generation of the event type.</param>
+/// <param name="Owner">The owner of the event type (Client types are the ones a developer usually cares about; Chronicle-owned types are framework-internal).</param>
+/// <param name="Tombstone">Whether the event type is a tombstone.</param>
+public record UnconsumedEventType(string Id, uint Generation, string Owner, bool Tombstone);


### PR DESCRIPTION
# Summary

The MCP server gains a design-time capability set alongside its operate-side tools. Where operate-side tools inspect and operate a live store, design-time tools turn natural language into Chronicle artifacts — read models, projections, audits, and catalogs — grounded in the store's real schema, never guessed. The server is also brought up to the Chronicle 16.x client.

## Added

- `describe_event_type` tool — an event type's real fields and types, read from its registered schema.
- `scaffold_read_model` tool — generates a reviewable read model + model-bound projection from chosen event types, surfaces existing projections that already read them, and returns no code (rather than a fabricated shape) when the requested event types are not registered.
- `audit_unconsumed_event_types` tool — reports event types nothing reads, plus consumers that reference an event type id that no longer exists.
- `generate_event_catalog` tool — a living data dictionary of every event type, its fields, and its consumers.
- `explain_causal_trace` tool — an event source's ordered history with correlation and causation, for narrating what happened and why.
- A Documentation folder covering getting started, configuration, how the server works, and a page per capability.

## Changed

- Updated to the Chronicle 16.x client (`Cratis.Chronicle.Connections`/`.Contracts` 16.0.6).

## Removed

- The `ManagementPort` option and its `CHRONICLE_MANAGEMENT_PORT` environment variable. In Chronicle 16.x the OAuth token endpoint is derived from the server address, so a separate management port is no longer used.