### PR TITLE
Add system-analysis capabilities: describe the system, suggest next event types, ad-hoc projections

### DIFF
--- a/Chronicle.Mcp.sln
+++ b/Chronicle.Mcp.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{B8EFCA5F-814F-285C-A8CB-F00F14650265}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chronicle.Mcp", "Source\Chronicle.Mcp.csproj", "{48B44107-918C-4E5F-990F-4A5017295CEB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Specs", "Specs", "{6808FED1-CAFD-922C-6811-EFA61D329B57}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chronicle.Mcp.Specs", "Specs\Chronicle.Mcp.Specs\Chronicle.Mcp.Specs.csproj", "{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,11 +33,24 @@ Global
 		{48B44107-918C-4E5F-990F-4A5017295CEB}.Release|x64.Build.0 = Release|Any CPU
 		{48B44107-918C-4E5F-990F-4A5017295CEB}.Release|x86.ActiveCfg = Release|Any CPU
 		{48B44107-918C-4E5F-990F-4A5017295CEB}.Release|x86.Build.0 = Release|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Debug|x64.Build.0 = Debug|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Debug|x86.Build.0 = Debug|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Release|x64.Build.0 = Release|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{48B44107-918C-4E5F-990F-4A5017295CEB} = {B8EFCA5F-814F-285C-A8CB-F00F14650265}
+		{72F80C3F-A3F1-40FB-8442-D5D44FFED1A1} = {6808FED1-CAFD-922C-6811-EFA61D329B57}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,20 +5,26 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.0.6" />
-    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.0.6" />
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.4" />
+    <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.11.1" />
+    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.11.1" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.6" />
     <!-- Roslyn-->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
     <!-- Analysis -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Orleans.Analyzers" Version="9.1.2" />
-    <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Orleans.Analyzers" Version="10.2.2" />
+    <PackageVersion Include="ModelContextProtocol" Version="2.0.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.122" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.137" />
+    <!-- Specifications -->
+    <PackageVersion Include="Cratis.Specifications.XUnit" Version="4.0.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
 </Project>

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -2,7 +2,7 @@
 
 Configuration is optional. The server works out of the box with defaults suited to local development:
 
-- **Connection string:** `chronicle://localhost:35000/?disableTls=true`
+- **Connection string:** `chronicle://localhost:35000`
 - **Credentials:** the development client id (`chronicle-dev-client`) and secret (`chronicle-dev-secret`)
 - **Event store / namespace:** `default` / `Default`
 
@@ -25,7 +25,7 @@ All options live under the `Cratis:Chronicle:Mcp` configuration section. As envi
 
 | Option | Environment variable | Description |
 | ------ | -------------------- | ----------- |
-| `ConnectionString` | `Cratis__Chronicle__Mcp__ConnectionString` | The Chronicle connection string. Defaults to `chronicle://localhost:35000/?disableTls=true`. |
+| `ConnectionString` | `Cratis__Chronicle__Mcp__ConnectionString` | The Chronicle connection string. Defaults to `chronicle://localhost:35000`. |
 | `Context` | `Cratis__Chronicle__Mcp__Context` | The CLI context to read connection details from. Defaults to the active context. |
 | `UseCliConfiguration` | `Cratis__Chronicle__Mcp__UseCliConfiguration` | Set to `false` to ignore `~/.cratis/config.json` entirely. |
 | `ClientId` / `ClientSecret` | `Cratis__Chronicle__Mcp__ClientId` / `...__ClientSecret` | Client credentials for authentication. Defaults to development credentials. |

--- a/Documentation/design-time/ad-hoc-projection.md
+++ b/Documentation/design-time/ad-hoc-projection.md
@@ -1,0 +1,49 @@
+# Ad-hoc projection
+
+*"Show all employees with all details."* In an event-sourced system, answering that means folding events into current state — and if no projection happens to exist for exactly that question, the answer traditionally requires writing one, deploying it, and waiting for it to catch up. `run_ad_hoc_projection` removes that loop: it materializes the answer on demand, straight from the store, without registering or persisting anything.
+
+Given the event types involved, the tool reads the matching events from the event sequence and folds them into per-event-source instances with the same semantics as an AutoMap projection: properties merge by name, later events overwrite earlier values, and removal events drop the instance. The result is the current state of every instance — computed in the moment, discarded after.
+
+## The natural-language flow
+
+The assistant resolves the question to event types; the tool does the folding:
+
+1. **Understand the system** — [describe the system](describe-system.md) or the [event catalog](event-catalog.md) reveals the entities and which event types carry which facts.
+2. **Pick the event types** — for *"all employees with all details"* that is every event contributing employee state: `EmployeeHired,EmployeeMoved,EmployeePromoted`, with `EmployeeTerminated` as a removal so former employees drop out.
+3. **Run the projection** — the tool folds the events and returns the instances.
+4. **Present the answer** — instances share a shape, so a table usually reads best.
+
+The `query_system` prompt packages exactly this flow: give it the natural-language question and it walks the assistant through resolving the event types and materializing the answer.
+
+## Parameters
+
+| Parameter | Required | Description |
+| --------- | -------- | ----------- |
+| `eventTypes` | yes | Comma-separated event type ids to fold. |
+| `removedWith` | no | Comma-separated event type ids that remove an instance. |
+| `eventStore` | no | The event store. Defaults to the configured event store. |
+| `namespace` | no | The namespace. Defaults to the configured namespace. |
+| `eventSequenceId` | no | The event sequence to read from. Defaults to `event-log`. |
+| `eventSourceId` | no | Scope to a single instance. |
+| `limit` | no | Maximum instances returned. Defaults to 100. |
+
+## What it returns
+
+- **Instances** — one per event source, each with its folded properties, the sequence number of the last event applied, and when it occurred.
+- **Counts** — how many events were folded and how many instances materialized (before the limit).
+- **Guidance** — how to present and refine the result.
+
+## From ad-hoc to permanent
+
+An ad-hoc projection is a probe. When the same question keeps coming back, that is the signal it deserves a real read model — hand the same event types to [read-model scaffolding](read-model-scaffolding.md) and turn the probe into a reviewable projection in your codebase.
+
+## Honest limits
+
+- The folding is AutoMap-shaped: top-level properties merge by name, last write wins. Joins, children collections, and computed values are projection-engine territory — reach for a real projection when you need them.
+- Every matching event is read from the sequence on each call. That is exactly right for design-time exploration and operational spot checks; it is not a serving layer for production queries.
+
+## Related
+
+- [Describe the system](describe-system.md) — find out which event types exist before folding them.
+- [Event catalog](event-catalog.md) — the field-level detail per event type.
+- [Read-model scaffolding](read-model-scaffolding.md) — make a recurring ad-hoc projection permanent.

--- a/Documentation/design-time/describe-system.md
+++ b/Documentation/design-time/describe-system.md
@@ -1,0 +1,45 @@
+# Describe the system
+
+You inherit an event store — or return to one after six months — and the first question is always the same: *what is this system, and what is it for?* The answer is already in the store. Event names are past-tense facts about subjects, so the names themselves carry which entities exist and what can happen to them. `describe_system` reads that language back out.
+
+Ask *"describe the system in Sales"* and the tool deduces a structural model from the registered metadata: it clusters event types into the entities they describe, places every event in its entity's lifecycle, and maps the read models and automations around them. The assistant then turns that model into prose — what the system is, and the story of how it behaves.
+
+## How the deduction works
+
+Everything is deduced from what the store actually contains — nothing is guessed from code or documentation:
+
+- **Entities** come from event type names. `AuthorRegistered`, `AuthorNameChanged`, and `AuthorRemoved` all name the same subject, so they cluster as the entity **Author**. Property-scoped clusters fold into their parent: with both `CustomerRegistered` and `CustomerAddressUpdated` present, "CustomerAddress" folds into **Customer** so the whole lifecycle sits together.
+- **Lifecycle stages** come from the verb: *Registered/Created/Hired* mark **Creation**, *Changed/Renamed/Assigned* mark **Mutation**, *Received/Shipped/LoggedIn* mark **Activity**, *Corrected/Redacted* mark **Correction**, and *Removed/Closed/Cancelled* mark **Termination**.
+- **Properties** come from each event type's registered JSON schema — the same field detail as [describe an event type](describe-event-type.md).
+- **Read surfaces** are the projections and reducers with the read models they build — what the business watches.
+- **Automations** are the reactors and external observers — what the system does on its own.
+
+## Parameters
+
+| Parameter | Required | Description |
+| --------- | -------- | ----------- |
+| `eventStore` | no | The event store to describe. Defaults to the configured event store. |
+| `namespace` | no | The namespace to resolve observers in. Defaults to the configured namespace. |
+
+## What it returns
+
+- **Entities** — each with its events ordered by lifecycle stage, and every event's properties.
+- **Read surfaces** — each read model with how it is built (projection or reducer) and the event types it derives from.
+- **Automations** — each observer with the event types that trigger it.
+- **Unconsumed event types** — facts the system records but nothing acts on yet.
+- **Statistics** — headline counts, and the namespaces present in the store.
+- **Narrative guidance** — instructions the assistant follows to turn the model into a description and a story.
+
+## Example
+
+**Prompt:** *"Describe the system in HR — and tell me its story."*
+
+From a store holding `EmployeeHired`, `EmployeeMoved`, `EmployeePromoted`, and `EmployeeTerminated`, plus an `AllEmployees` projection and an `OnboardingNotifier` reactor, the assistant deduces an HR system centered on the **Employee** entity and narrates it: an employee's story begins when they are hired with a name and title; along the way they can move (the events carry the address vocabulary) and be promoted; the business watches all employees through `AllEmployees`; and when someone is hired, the system acts on its own to start onboarding. Termination ends the story.
+
+The `describe_system` prompt packages this workflow, so clients that surface MCP prompts can offer it directly.
+
+## Related
+
+- [Suggest the next event types](suggest-next-event-types.md) — the same deduced model, used to find the gaps.
+- [Event catalog](event-catalog.md) — the flat data dictionary underneath the narrative.
+- [Ad-hoc projection](ad-hoc-projection.md) — query the described system's actual data.

--- a/Documentation/design-time/index.md
+++ b/Documentation/design-time/index.md
@@ -6,22 +6,35 @@ The design-time tools turn a plain-language request into Chronicle artifacts —
 
 | Capability | Tool | Use it to |
 | ---------- | ---- | --------- |
+| [Describe the system](describe-system.md) | `describe_system` | Deduce what the system is and is for — entities, lifecycles, read surfaces, automations — and tell its story. |
+| [Suggest the next event types](suggest-next-event-types.md) | `suggest_next_event_types` | Find lifecycle gaps and get grounded suggestions for the event types to introduce next. |
+| [Ad-hoc projection](ad-hoc-projection.md) | `run_ad_hoc_projection` | Answer "show all X with all details" by folding events into current state on demand — nothing registered. |
 | [Describe an event type](describe-event-type.md) | `describe_event_type` | Read an event type's real fields and types — the grounding primitive the others build on. |
 | [Read-model scaffolding](read-model-scaffolding.md) | `scaffold_read_model` | Turn a set of event types into a reviewable read model + projection, grounded in their schema. |
 | [Unconsumed-event audit](unconsumed-event-audit.md) | `audit_unconsumed_event_types` | Find events nothing reads, and consumers pointing at event types that no longer exist. |
 | [Event catalog](event-catalog.md) | `generate_event_catalog` | Produce a living data dictionary — every event, its fields, and its consumers. |
 | [Causal trace](causal-trace.md) | `explain_causal_trace` | Turn an event source's raw log into a "what happened and why" narrative. |
 
+## Prompts
+
+Beyond tools, the server exposes MCP prompts that package whole workflows — clients that surface prompts (for example as slash commands) can offer them directly:
+
+| Prompt | What it does |
+| ------ | ------------ |
+| `describe_system` | Describe what the system is and is for, and tell its story. |
+| `suggest_next_event_types` | Propose the next event types, refined with domain knowledge. |
+| `query_system` | Answer a natural-language question ("show all employees with all details") with an ad-hoc projection. |
+
 ## How an agent combines them
 
-A typical flow chains a few tools. To answer *"Show me all the users registered"* an agent might:
+A typical flow chains a few tools. To answer *"Show all employees with all details"* an agent might:
 
-1. Resolve candidate event types (`list_event_types`, or [Event catalog](event-catalog.md)).
-2. Inspect their real fields with [describe an event type](describe-event-type.md).
-3. Check whether a projection already answers the question, then propose one with [read-model scaffolding](read-model-scaffolding.md).
+1. Understand the system with [describe the system](describe-system.md) — which entities exist and which event types carry which facts.
+2. Fold the relevant event types into current state with an [ad-hoc projection](ad-hoc-projection.md) and present the result.
+3. If the question keeps coming back, propose a permanent read model with [read-model scaffolding](read-model-scaffolding.md).
 
 Because the tools return structured data rather than prose, the agent does the natural-language reasoning while the store supplies the facts.
 
 ## Roadmap
 
-The [capability hand-off](https://github.com/Cratis/Chronicle.Mcp) sketches ten design-time capabilities. The five above are the grounding-and-generation core. The remaining ideas — missing-event-type suggestions, projection-vs-reducer advice, consistency-boundary (DCB) advice, schema-evolution assistance, spec scaffolding, and constraint suggestions — build on the same introspection pipeline and are candidates for future releases.
+The [capability hand-off](https://github.com/Cratis/Chronicle.Mcp) sketches ten design-time capabilities. The tools above cover the grounding-and-generation core plus system understanding, evolution suggestions, and ad-hoc querying. The remaining ideas — projection-vs-reducer advice, consistency-boundary (DCB) advice, schema-evolution assistance, spec scaffolding, and constraint suggestions — build on the same introspection pipeline and are candidates for future releases.

--- a/Documentation/design-time/suggest-next-event-types.md
+++ b/Documentation/design-time/suggest-next-event-types.md
@@ -1,0 +1,42 @@
+# Suggest the next event types
+
+A growing event model develops blind spots: an entity that can be created but never removed, a value set once at registration that the business later needs to change, a lifecycle whose beginning is implicit. You usually discover these gaps the hard way — when a feature needs an event that does not exist. `suggest_next_event_types` finds them first.
+
+Ask *"what event types should I introduce next for the system in Sales?"* and the tool deduces the system's entities and lifecycles from the registered event types (the same deduction as [describe the system](describe-system.md)), then runs deterministic gap analysis over them. Every suggestion names the concrete gap it closes — these are grounded findings, not brainstorming.
+
+## The gaps it finds
+
+- **No explicit creation** — an entity's first recorded fact is a mutation or termination, so its lifecycle starts implicitly. Suggests an explicit creation event that gives projections a reliable initialization point.
+- **A life without an end** — the entity has a beginning but nothing ever removes, closes, or archives it. Suggests a termination event so read models can clear state (`[RemovedWith]`) and compliance and cleanup have a fact to act on.
+- **Facts frozen at creation** — a property is set when the entity comes to life and no later event ever touches it. If the business allows it to change, that change needs its own event. Identifier properties are excluded — those genuinely never change.
+
+## Parameters
+
+| Parameter | Required | Description |
+| --------- | -------- | ----------- |
+| `eventStore` | no | The event store to analyze. Defaults to the configured event store. |
+| `entity` | no | An entity name to scope the suggestions to (case-insensitive). Omit for the whole system. |
+
+## What it returns
+
+- **Suggestions** — each with a suggested name (past tense, one purpose), the entity and lifecycle stage it completes, the rationale naming the gap, and candidate properties drawn from the existing schema.
+- **The entities analyzed** — so the assistant can reason about the suggestions in context.
+- **Guidance** — instructions for refining the seeds with domain knowledge.
+
+## The suggestions are seeds
+
+The analysis is deliberately mechanical so it never invents facts — which means the names need the domain's own language. The guidance tells the assistant to refine them: a Book is *Withdrawn*, not *Removed*; an Order is *Cancelled*, not *Deleted*; and some facts really are immutable, in which case the right answer is to discard the suggestion and say why.
+
+## Example
+
+**Prompt:** *"What event types should I introduce next for the system in CRM?"*
+
+From a store holding `CustomerRegistered` (with `Email`, `FullName`, `PhoneNumber`) and `CustomerAddressUpdated`, the analysis finds that nothing ever ends a customer's life, and that email, name, and phone number are frozen at registration. The assistant proposes `CustomerRemoved` (or, refined, `CustomerOffboarded`), plus `CustomerEmailChanged`, `CustomerFullNameChanged`, and `CustomerPhoneNumberChanged` — each carrying its property from the existing schema — and notes which ones the business may not need.
+
+The `suggest_next_event_types` prompt packages this workflow for clients that surface MCP prompts.
+
+## Related
+
+- [Describe the system](describe-system.md) — the deduced model the analysis runs over.
+- [Unconsumed-event audit](unconsumed-event-audit.md) — the complementary gap: events that exist but nothing reads.
+- [Read-model scaffolding](read-model-scaffolding.md) — once the new events exist, project them.

--- a/Documentation/design-time/toc.yml
+++ b/Documentation/design-time/toc.yml
@@ -1,5 +1,11 @@
 - name: Overview
   href: index.md
+- name: Describe the system
+  href: describe-system.md
+- name: Suggest the next event types
+  href: suggest-next-event-types.md
+- name: Ad-hoc projection
+  href: ad-hoc-projection.md
 - name: Describe an event type
   href: describe-event-type.md
 - name: Read-model scaffolding

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -42,6 +42,9 @@ Once the server is connected, your agent can reach the store. Start with the ope
 
 Then try the design-time capabilities, which turn a plain request into a grounded artifact:
 
+- "Describe the system in this event store" → the agent deduces entities and lifecycles with [describe the system](design-time/describe-system.md) and tells the system's story.
+- "Show all employees with all details" → an [ad-hoc projection](design-time/ad-hoc-projection.md) folds the events into current state on demand.
+- "What event types should I introduce next?" → grounded gap findings from [suggest the next event types](design-time/suggest-next-event-types.md).
 - "Show me all the users registered" → the agent resolves the event types, then proposes a read model with [read-model scaffolding](design-time/read-model-scaffolding.md).
 - "What events are we writing that nothing reads?" → an [unconsumed-event audit](design-time/unconsumed-event-audit.md).
 - "Why does this order show as cancelled?" → a [causal trace](design-time/causal-trace.md) of the order's history.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can see this in action in the [mcp.json](./.vscode/mcp.json) in this reposit
 
 **Configuration is optional.** The MCP server works out of the box with sensible defaults suitable for local development:
 
-- **Connection String:** `chronicle://host.docker.internal:35000/?disableTls=true`
+- **Connection String:** `chronicle://host.docker.internal:35000`
 - **Credentials:** Development client ID (`chronicle-dev-client`) and secret (`chronicle-dev-secret`)
 
 If you need to customize any settings, the MCP server can be configured entirely on its own and is also compatible with the
@@ -88,7 +88,7 @@ they use the `Cratis__Chronicle__Mcp__` prefix:
 
 | Option | Environment variable | Description |
 | ------ | -------------------- | ----------- |
-| `ConnectionString` | `Cratis__Chronicle__Mcp__ConnectionString` | The Chronicle connection string. Defaults to `chronicle://localhost:35000/?disableTls=true`. |
+| `ConnectionString` | `Cratis__Chronicle__Mcp__ConnectionString` | The Chronicle connection string. Defaults to `chronicle://localhost:35000`. |
 | `Context` | `Cratis__Chronicle__Mcp__Context` | The CLI context to read connection details from (defaults to the active context). |
 | `UseCliConfiguration` | `Cratis__Chronicle__Mcp__UseCliConfiguration` | Set to `false` to ignore `~/.cratis/config.json` entirely. |
 | `ClientId` / `ClientSecret` | `Cratis__Chronicle__Mcp__ClientId` / `...__ClientSecret` | Client credentials for authentication. Defaults to development credentials if not specified. |
@@ -135,11 +135,16 @@ store's real schema. See the [Documentation](./Documentation/index.md) folder fo
 
 | Tool | Description |
 | ---- | ----------- |
+| `describe_system` | Deduce what the system in an event store is and is for — entities, lifecycles, read surfaces, automations — with narrative guidance for telling its story. |
+| `suggest_next_event_types` | Find lifecycle gaps and suggest the event types to introduce next, each grounded in the gap it closes. |
+| `run_ad_hoc_projection` | Fold events into per-event-source instances on demand (AutoMap semantics) — answer "show all X with all details" without registering anything. |
 | `describe_event_type` | Describe an event type's real schema — every property with its JSON and suggested C# type. The grounding primitive for the others. |
 | `scaffold_read_model` | Generate a reviewable read model + model-bound projection from one or more event types, grounded in their schema. |
 | `audit_unconsumed_event_types` | Report event types nothing reads, plus consumers that reference an event type id that no longer exists. |
 | `generate_event_catalog` | Produce a living data dictionary — every event type, its fields, and its consumers. |
 | `explain_causal_trace` | Read an event source's ordered history with correlation and causation, to narrate what happened and why. |
+
+The server also exposes MCP **prompts** — `describe_system`, `suggest_next_event_types`, and `query_system` — that package these workflows for clients that surface prompts (for example as slash commands).
 
 You can ask it things like:
 
@@ -156,6 +161,9 @@ You can ask it things like:
 
 And design-time questions like:
 
+- Describe the system in [put event store here] — and tell me its story
+- What event types should I introduce next for the system in [put event store here]?
+- Show all [put concept here] with all details (runs an ad-hoc projection)
 - Show me all the [put concept here] registered (scaffolds a read model + projection)
 - What fields does the [put event type here] event have?
 - What events are we writing that nothing reads?

--- a/Source/Configuration/ChronicleConnectionConfiguration.cs
+++ b/Source/Configuration/ChronicleConnectionConfiguration.cs
@@ -34,7 +34,7 @@ public class ChronicleConnectionConfiguration(IOptions<McpServerOptions> options
     /// </summary>
     public const string ConnectionStringEnvVar = "CHRONICLE_CONNECTION_STRING";
 
-    const string DefaultConnectionString = "chronicle://localhost:35000/?disableTls=true";
+    const string DefaultConnectionString = "chronicle://localhost:35000";
     const string Scheme = "chronicle://";
 
     readonly McpServerOptions _options = options.Value;

--- a/Source/Connection/ChronicleMcpServiceCollectionExtensions.cs
+++ b/Source/Connection/ChronicleMcpServiceCollectionExtensions.cs
@@ -64,7 +64,7 @@ public static class ChronicleMcpServiceCollectionExtensions
             loggerFactory,
             lifetime.ApplicationStopping,
             loggerFactory.CreateLogger<ChronicleConnection>(),
-            connectionString.DisableTls,
+            connectionString.SkipTlsValidation,
             connectionString.CertificatePath,
             connectionString.CertificatePassword,
             tokenProvider,
@@ -93,7 +93,7 @@ public static class ChronicleMcpServiceCollectionExtensions
             connectionString.ServerAddress,
             connectionString.Username ?? string.Empty,
             connectionString.Password ?? string.Empty,
-            connectionString.DisableTls,
+            connectionString.SkipTlsValidation,
             loggerFactory.CreateLogger<OAuthTokenProvider>());
 #pragma warning restore CA2000
 

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -29,7 +29,8 @@ builder.Services.AddChronicleMcpConnection();
 builder.Services
     .AddMcpServer()
     .WithStdioServerTransport()
-    .WithToolsFromAssembly();
+    .WithToolsFromAssembly()
+    .WithPromptsFromAssembly();
 
 var host = builder.Build();
 await host.RunAsync();

--- a/Source/Tools/Design/AdHocEvent.cs
+++ b/Source/Tools/Design/AdHocEvent.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// An event prepared for ad-hoc folding — the minimal shape the folder needs.
+/// </summary>
+/// <param name="EventSourceId">The event source the event belongs to.</param>
+/// <param name="EventType">The event type id.</param>
+/// <param name="SequenceNumber">The event's position in the sequence.</param>
+/// <param name="Occurred">When the event occurred.</param>
+/// <param name="Content">The event's JSON content, when parseable.</param>
+public record AdHocEvent(
+    string EventSourceId,
+    string EventType,
+    ulong SequenceNumber,
+    DateTimeOffset? Occurred,
+    JsonElement? Content);

--- a/Source/Tools/Design/AdHocProjectionInstance.cs
+++ b/Source/Tools/Design/AdHocProjectionInstance.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// One instance materialized by an ad-hoc projection — the current state of one event source,
+/// folded from the selected events.
+/// </summary>
+/// <param name="EventSourceId">The event source the instance represents.</param>
+/// <param name="Properties">The folded properties — later events overwrite earlier ones per property name.</param>
+/// <param name="LastEventSequenceNumber">The sequence number of the last event folded into the instance.</param>
+/// <param name="LastOccurred">When the last folded event occurred.</param>
+public record AdHocProjectionInstance(
+    string EventSourceId,
+    IReadOnlyDictionary<string, JsonElement> Properties,
+    ulong LastEventSequenceNumber,
+    DateTimeOffset? LastOccurred);

--- a/Source/Tools/Design/AdHocProjectionResult.cs
+++ b/Source/Tools/Design/AdHocProjectionResult.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// The result of an ad-hoc projection — instances materialized on demand from the selected
+/// events, without registering anything in the store.
+/// </summary>
+/// <param name="EventStore">The event store the events were read from.</param>
+/// <param name="Namespace">The namespace the events were read in.</param>
+/// <param name="EventTypes">The event types that were folded.</param>
+/// <param name="RemovedWithEventTypes">The event types that removed instances.</param>
+/// <param name="Instances">The materialized instances, capped at the requested limit.</param>
+/// <param name="TotalInstances">The total number of instances materialized before capping.</param>
+/// <param name="FoldedEvents">The number of events that were folded.</param>
+/// <param name="Guidance">Instructions for presenting the result and refining the projection.</param>
+public record AdHocProjectionResult(
+    string EventStore,
+    string Namespace,
+    IReadOnlyList<string> EventTypes,
+    IReadOnlyList<string> RemovedWithEventTypes,
+    IReadOnlyList<AdHocProjectionInstance> Instances,
+    int TotalInstances,
+    int FoldedEvents,
+    string Guidance);

--- a/Source/Tools/Design/AdHocProjectionTools.cs
+++ b/Source/Tools/Design/AdHocProjectionTools.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Text.Json;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Contracts.EventSequences;
+using Cratis.Chronicle.Mcp.Configuration;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Design-time tool that answers ad-hoc questions by projecting events on demand. Given the event
+/// types involved, it reads the matching events from the store and folds them into per-event-source
+/// instances the way an AutoMap projection would — without registering or persisting anything.
+/// This is what turns "show all employees with all details" into a result set.
+/// </summary>
+[McpServerToolType]
+public static class AdHocProjectionTools
+{
+    const string DefaultEventSequenceId = "event-log";
+
+    const string Guidance =
+        "Present the instances in the domain's language — a table works well when they share a shape. Later events " +
+        "overwrite earlier property values by name (AutoMap semantics), so each instance shows current state. To refine: " +
+        "add event types that carry the missing details, add removedWith event types so ended instances drop out, or scope " +
+        "to a single eventSourceId for one instance's state. If this projection answers a recurring question, propose making " +
+        "it permanent with scaffold_read_model.";
+
+    /// <summary>
+    /// Projects events into per-event-source instances on demand.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="eventTypes">Comma-separated event type ids to fold.</param>
+    /// <param name="removedWith">Optional comma-separated event type ids that remove an instance.</param>
+    /// <param name="eventStore">The event store. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace. Defaults to the configured namespace.</param>
+    /// <param name="eventSequenceId">The event sequence to read from. Defaults to event-log.</param>
+    /// <param name="eventSourceId">An optional event source id to scope to a single instance.</param>
+    /// <param name="limit">The maximum number of instances to return. Defaults to 100.</param>
+    /// <returns>The <see cref="AdHocProjectionResult"/> with the materialized instances.</returns>
+    [McpServerTool(Name = "run_ad_hoc_projection")]
+    [Description("Answers ad-hoc queries by projecting events on demand: reads the given event types from the store and folds them into per-event-source instances with AutoMap semantics (later events overwrite earlier property values; removedWith event types drop the instance). Nothing is registered or written. First resolve which event types are involved (describe_system or generate_event_catalog), then call this with them. Use it for natural-language questions like 'show all employees with all details'.")]
+    public static async Task<AdHocProjectionResult> RunAdHocProjection(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("Comma-separated event type ids to fold (e.g. EmployeeHired,EmployeeMoved,EmployeePromoted).")] string eventTypes,
+        [Description("Optional comma-separated event type ids that remove an instance (e.g. EmployeeTerminated).")] string? removedWith = null,
+        [Description("The event store. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace. Defaults to the configured namespace.")] string? @namespace = null,
+        [Description("The event sequence to read from. Defaults to event-log.")] string eventSequenceId = DefaultEventSequenceId,
+        [Description("An optional event source id to scope to a single instance.")] string? eventSourceId = null,
+        [Description("The maximum number of instances to return. Defaults to 100.")] int limit = 100)
+    {
+        var resolvedEventStore = configuration.ResolveEventStore(eventStore);
+        var resolvedNamespace = configuration.ResolveNamespace(@namespace);
+        var foldTypes = Split(eventTypes);
+        var removalTypes = Split(removedWith);
+
+        var request = new GetFromEventSequenceNumberRequest
+        {
+            EventStore = resolvedEventStore,
+            Namespace = resolvedNamespace,
+            EventSequenceId = eventSequenceId,
+            FromEventSequenceNumber = 0,
+            EventSourceId = string.IsNullOrWhiteSpace(eventSourceId) ? null : eventSourceId
+        };
+
+        foreach (var eventTypeId in foldTypes.Concat(removalTypes))
+        {
+            request.EventTypes.Add(new EventType { Id = eventTypeId, Generation = 1u });
+        }
+
+        var response = await services.EventSequences.GetEventsFromEventSequenceNumber(request);
+
+        var events = response.Events.Select(evt => new AdHocEvent(
+            evt.Context.EventSourceId,
+            evt.Context.EventType?.Id ?? string.Empty,
+            evt.Context.SequenceNumber,
+            (DateTimeOffset?)evt.Context.Occurred,
+            TryParse(evt.Content))).ToList();
+
+        var instances = AdHocProjector.Fold(events, removalTypes);
+
+        return new AdHocProjectionResult(
+            resolvedEventStore,
+            resolvedNamespace,
+            foldTypes,
+            removalTypes,
+            instances.Take(limit).ToList(),
+            instances.Count,
+            events.Count,
+            Guidance);
+    }
+
+    static List<string> Split(string? input) =>
+        (input ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
+
+    static JsonElement? TryParse(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<JsonElement>(content);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/Source/Tools/Design/AdHocProjector.cs
+++ b/Source/Tools/Design/AdHocProjector.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Folds a stream of events into per-event-source instances the way a Chronicle projection with
+/// AutoMap would: properties merge by name, later events overwrite earlier ones, and removal
+/// events drop the instance. This runs entirely in the MCP server against events read from the
+/// store — nothing is registered or written.
+/// </summary>
+public static class AdHocProjector
+{
+    /// <summary>
+    /// Folds events, ordered by sequence number, into the current state per event source.
+    /// </summary>
+    /// <param name="events">The events to fold.</param>
+    /// <param name="removedWithEventTypes">Event type ids that remove an instance (case-insensitive).</param>
+    /// <returns>The materialized instances, ordered by event source id.</returns>
+    public static IReadOnlyList<AdHocProjectionInstance> Fold(
+        IEnumerable<AdHocEvent> events,
+        IEnumerable<string>? removedWithEventTypes = null)
+    {
+        var removedWith = (removedWithEventTypes ?? []).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var instances = new Dictionary<string, InstanceState>(StringComparer.Ordinal);
+
+        foreach (var @event in events.OrderBy(entry => entry.SequenceNumber))
+        {
+            if (removedWith.Contains(@event.EventType))
+            {
+                instances.Remove(@event.EventSourceId);
+                continue;
+            }
+
+            if (!instances.TryGetValue(@event.EventSourceId, out var instance))
+            {
+                instance = new InstanceState();
+                instances[@event.EventSourceId] = instance;
+            }
+
+            Merge(instance.Properties, @event.Content);
+            instance.LastEventSequenceNumber = @event.SequenceNumber;
+            instance.LastOccurred = @event.Occurred;
+        }
+
+        return instances
+            .OrderBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(entry => new AdHocProjectionInstance(
+                entry.Key,
+                entry.Value.Properties,
+                entry.Value.LastEventSequenceNumber,
+                entry.Value.LastOccurred))
+            .ToList();
+    }
+
+    static void Merge(Dictionary<string, JsonElement> properties, JsonElement? content)
+    {
+        if (content is not { ValueKind: JsonValueKind.Object } value)
+        {
+            return;
+        }
+
+        foreach (var property in value.EnumerateObject())
+        {
+            properties[property.Name] = property.Value;
+        }
+    }
+
+    sealed class InstanceState
+    {
+        public Dictionary<string, JsonElement> Properties { get; } = new(StringComparer.Ordinal);
+
+        public ulong LastEventSequenceNumber { get; set; }
+
+        public DateTimeOffset? LastOccurred { get; set; }
+    }
+}

--- a/Source/Tools/Design/DesignIntrospection.cs
+++ b/Source/Tools/Design/DesignIntrospection.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Contracts.Observation;
 using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Contracts.ReadModels;
 
 namespace Cratis.Chronicle.Mcp.Tools.Design;
 
@@ -45,6 +47,71 @@ public static class DesignIntrospection
         var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         CollectFromLevel(projection.From, projection.Join, projection.RemovedWith, projection.RemovedWithJoin, projection.FromEventProperty, projection.Children, projection.Nested, ids);
         return ids;
+    }
+
+    /// <summary>
+    /// Builds an index from event type id to every projection, reducer, and reactor consuming it.
+    /// </summary>
+    /// <param name="projections">The projection definitions from the store.</param>
+    /// <param name="observers">The observers registered in the namespace.</param>
+    /// <param name="readModels">The read model definitions, used to resolve observer read model names.</param>
+    /// <returns>The consumer index keyed by event type id (case-insensitive).</returns>
+    public static IReadOnlyDictionary<string, IReadOnlyList<EventCatalogConsumer>> BuildConsumerIndex(
+        IEnumerable<ProjectionDefinition> projections,
+        IEnumerable<ObserverInformation> observers,
+        IEnumerable<ReadModelDefinition> readModels)
+    {
+        var readModelByObserverId = readModels
+            .Where(readModel => !string.IsNullOrEmpty(readModel.ObserverIdentifier))
+            .GroupBy(readModel => readModel.ObserverIdentifier, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => ReadModelName(group.First()), StringComparer.Ordinal);
+
+        var index = new Dictionary<string, List<EventCatalogConsumer>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var projection in projections)
+        {
+            var consumer = new EventCatalogConsumer(nameof(ObserverType.Projection), projection.Identifier, string.IsNullOrWhiteSpace(projection.ReadModel) ? null : projection.ReadModel);
+            foreach (var eventTypeId in CollectConsumedEventTypeIds(projection))
+            {
+                Add(index, eventTypeId, consumer);
+            }
+        }
+
+        foreach (var observer in observers.Where(observer => observer.Type != ObserverType.Projection))
+        {
+            var readModel = readModelByObserverId.TryGetValue(observer.Id, out var name) ? name : null;
+            var consumer = new EventCatalogConsumer(observer.Type.ToString(), observer.Id, readModel);
+            foreach (var eventTypeId in (observer.EventTypes ?? []).Select(eventType => eventType.Id).Where(id => !string.IsNullOrEmpty(id)))
+            {
+                Add(index, eventTypeId, consumer);
+            }
+        }
+
+        return index.ToDictionary(entry => entry.Key, entry => (IReadOnlyList<EventCatalogConsumer>)entry.Value, StringComparer.OrdinalIgnoreCase);
+    }
+
+    static string? ReadModelName(ReadModelDefinition readModel)
+    {
+        if (!string.IsNullOrWhiteSpace(readModel.DisplayName))
+        {
+            return readModel.DisplayName;
+        }
+
+        return string.IsNullOrWhiteSpace(readModel.ContainerName) ? null : readModel.ContainerName;
+    }
+
+    static void Add(Dictionary<string, List<EventCatalogConsumer>> index, string eventTypeId, EventCatalogConsumer consumer)
+    {
+        if (!index.TryGetValue(eventTypeId, out var consumers))
+        {
+            consumers = [];
+            index[eventTypeId] = consumers;
+        }
+
+        if (!consumers.Exists(existing => existing.Type == consumer.Type && existing.Id == consumer.Id))
+        {
+            consumers.Add(consumer);
+        }
     }
 
     static void CollectFromLevel(

--- a/Source/Tools/Design/EventCatalogTools.cs
+++ b/Source/Tools/Design/EventCatalogTools.cs
@@ -46,7 +46,7 @@ public static class EventCatalogTools
         var observers = (await services.Observers.GetObservers(new AllObserversRequest { EventStore = resolvedEventStore, Namespace = resolvedNamespace })).ToList();
         var readModels = (await services.ReadModels.GetDefinitions(new GetDefinitionsRequest { EventStore = resolvedEventStore })).ReadModels;
 
-        var consumersByEventType = BuildConsumerIndex(projections, observers, readModels);
+        var consumersByEventType = DesignIntrospection.BuildConsumerIndex(projections, observers, readModels);
 
         return registrations
             .GroupBy(registration => registration.Type.Id, StringComparer.OrdinalIgnoreCase)
@@ -65,64 +65,6 @@ public static class EventCatalogTools
             .ToList();
     }
 
-    static List<EventCatalogConsumer> Consumers(Dictionary<string, List<EventCatalogConsumer>> index, string eventTypeId) =>
+    static IReadOnlyList<EventCatalogConsumer> Consumers(IReadOnlyDictionary<string, IReadOnlyList<EventCatalogConsumer>> index, string eventTypeId) =>
         index.TryGetValue(eventTypeId, out var consumers) ? consumers : [];
-
-    static Dictionary<string, List<EventCatalogConsumer>> BuildConsumerIndex(
-        IEnumerable<ProjectionDefinition> projections,
-        IEnumerable<ObserverInformation> observers,
-        IEnumerable<ReadModelDefinition> readModels)
-    {
-        var readModelByObserverId = readModels
-            .Where(readModel => !string.IsNullOrEmpty(readModel.ObserverIdentifier))
-            .GroupBy(readModel => readModel.ObserverIdentifier, StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => ReadModelName(group.First()), StringComparer.Ordinal);
-
-        var index = new Dictionary<string, List<EventCatalogConsumer>>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var projection in projections)
-        {
-            var consumer = new EventCatalogConsumer(nameof(ObserverType.Projection), projection.Identifier, string.IsNullOrWhiteSpace(projection.ReadModel) ? null : projection.ReadModel);
-            foreach (var eventTypeId in DesignIntrospection.CollectConsumedEventTypeIds(projection))
-            {
-                Add(index, eventTypeId, consumer);
-            }
-        }
-
-        foreach (var observer in observers.Where(observer => observer.Type != ObserverType.Projection))
-        {
-            var readModel = readModelByObserverId.TryGetValue(observer.Id, out var name) ? name : null;
-            var consumer = new EventCatalogConsumer(observer.Type.ToString(), observer.Id, readModel);
-            foreach (var eventTypeId in (observer.EventTypes ?? []).Select(eventType => eventType.Id).Where(id => !string.IsNullOrEmpty(id)))
-            {
-                Add(index, eventTypeId, consumer);
-            }
-        }
-
-        return index;
-    }
-
-    static string? ReadModelName(ReadModelDefinition readModel)
-    {
-        if (!string.IsNullOrWhiteSpace(readModel.DisplayName))
-        {
-            return readModel.DisplayName;
-        }
-
-        return string.IsNullOrWhiteSpace(readModel.ContainerName) ? null : readModel.ContainerName;
-    }
-
-    static void Add(Dictionary<string, List<EventCatalogConsumer>> index, string eventTypeId, EventCatalogConsumer consumer)
-    {
-        if (!index.TryGetValue(eventTypeId, out var consumers))
-        {
-            consumers = [];
-            index[eventTypeId] = consumers;
-        }
-
-        if (!consumers.Exists(existing => existing.Type == consumer.Type && existing.Id == consumer.Id))
-        {
-            consumers.Add(consumer);
-        }
-    }
 }

--- a/Source/Tools/Design/EventNameMorphology.cs
+++ b/Source/Tools/Design/EventNameMorphology.cs
@@ -1,0 +1,234 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Deduces structure from event type names. Event names are the ubiquitous language of an
+/// event-sourced system — a well-named event is a past-tense fact about a subject, so the name
+/// itself carries which entity it belongs to and where in that entity's lifecycle it sits.
+/// </summary>
+public static class EventNameMorphology
+{
+    static readonly HashSet<string> _particles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "In", "Out", "Up", "Down", "On", "Off", "Over", "Back", "To", "From"
+    };
+
+    static readonly HashSet<string> _irregularVerbs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Sent", "Built", "Made", "Won", "Lost", "Sold", "Bought", "Paid", "Held", "Left", "Kept",
+        "Met", "Set", "Put", "Reset", "Split", "Shut", "Begun", "Drawn", "Withdrawn", "Given",
+        "Taken", "Chosen", "Frozen", "Broken", "Hidden", "Written", "Overridden", "Done", "Undone",
+        "Gone", "Born", "Torn", "Worn", "Sworn", "Shown", "Known", "Grown", "Flown", "Thrown",
+        "Sung", "Rung", "Hung", "Struck", "Stuck", "Spent", "Lent", "Bent", "Burnt", "Learnt",
+        "Meant", "Felt", "Dealt", "Found", "Bound", "Wound", "Caught", "Taught", "Brought", "Sought"
+    };
+
+    static readonly Dictionary<string, LifecycleStage> _verbStages = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Creation — the entity comes into existence.
+        ["Registered"] = LifecycleStage.Creation,
+        ["Created"] = LifecycleStage.Creation,
+        ["Added"] = LifecycleStage.Creation,
+        ["Opened"] = LifecycleStage.Creation,
+        ["Started"] = LifecycleStage.Creation,
+        ["Placed"] = LifecycleStage.Creation,
+        ["Submitted"] = LifecycleStage.Creation,
+        ["Imported"] = LifecycleStage.Creation,
+        ["Onboarded"] = LifecycleStage.Creation,
+        ["Initialized"] = LifecycleStage.Creation,
+        ["Initiated"] = LifecycleStage.Creation,
+        ["Established"] = LifecycleStage.Creation,
+        ["Enrolled"] = LifecycleStage.Creation,
+        ["Joined"] = LifecycleStage.Creation,
+        ["Founded"] = LifecycleStage.Creation,
+        ["Launched"] = LifecycleStage.Creation,
+        ["Provisioned"] = LifecycleStage.Creation,
+        ["Issued"] = LifecycleStage.Creation,
+        ["SignedUp"] = LifecycleStage.Creation,
+        ["Hired"] = LifecycleStage.Creation,
+        ["Appointed"] = LifecycleStage.Creation,
+        ["Admitted"] = LifecycleStage.Creation,
+
+        // Termination — the entity's life ends.
+        ["Removed"] = LifecycleStage.Termination,
+        ["Deleted"] = LifecycleStage.Termination,
+        ["Closed"] = LifecycleStage.Termination,
+        ["Cancelled"] = LifecycleStage.Termination,
+        ["Canceled"] = LifecycleStage.Termination,
+        ["Archived"] = LifecycleStage.Termination,
+        ["Terminated"] = LifecycleStage.Termination,
+        ["Ended"] = LifecycleStage.Termination,
+        ["Completed"] = LifecycleStage.Termination,
+        ["Finished"] = LifecycleStage.Termination,
+        ["Expired"] = LifecycleStage.Termination,
+        ["Revoked"] = LifecycleStage.Termination,
+        ["Unregistered"] = LifecycleStage.Termination,
+        ["Erased"] = LifecycleStage.Termination,
+        ["Withdrawn"] = LifecycleStage.Termination,
+        ["Retired"] = LifecycleStage.Termination,
+        ["Discarded"] = LifecycleStage.Termination,
+        ["Abandoned"] = LifecycleStage.Termination,
+        ["Dissolved"] = LifecycleStage.Termination,
+        ["Fired"] = LifecycleStage.Termination,
+        ["Dismissed"] = LifecycleStage.Termination,
+        ["Resigned"] = LifecycleStage.Termination,
+
+        // Correction — an earlier fact is corrected or reversed.
+        ["Corrected"] = LifecycleStage.Correction,
+        ["Adjusted"] = LifecycleStage.Correction,
+        ["Amended"] = LifecycleStage.Correction,
+        ["Reverted"] = LifecycleStage.Correction,
+        ["Undone"] = LifecycleStage.Correction,
+        ["Redacted"] = LifecycleStage.Correction,
+        ["Rectified"] = LifecycleStage.Correction,
+
+        // Mutation — existing state changes.
+        ["Changed"] = LifecycleStage.Mutation,
+        ["Updated"] = LifecycleStage.Mutation,
+        ["Renamed"] = LifecycleStage.Mutation,
+        ["Modified"] = LifecycleStage.Mutation,
+        ["Set"] = LifecycleStage.Mutation,
+        ["Reset"] = LifecycleStage.Mutation,
+        ["Assigned"] = LifecycleStage.Mutation,
+        ["Reassigned"] = LifecycleStage.Mutation,
+        ["Unassigned"] = LifecycleStage.Mutation,
+        ["Moved"] = LifecycleStage.Mutation,
+        ["Transferred"] = LifecycleStage.Mutation,
+        ["Increased"] = LifecycleStage.Mutation,
+        ["Decreased"] = LifecycleStage.Mutation,
+        ["Enabled"] = LifecycleStage.Mutation,
+        ["Disabled"] = LifecycleStage.Mutation,
+        ["Activated"] = LifecycleStage.Mutation,
+        ["Reactivated"] = LifecycleStage.Mutation,
+        ["Deactivated"] = LifecycleStage.Mutation,
+        ["Suspended"] = LifecycleStage.Mutation,
+        ["Resumed"] = LifecycleStage.Mutation,
+        ["Paused"] = LifecycleStage.Mutation,
+        ["Promoted"] = LifecycleStage.Mutation,
+        ["Demoted"] = LifecycleStage.Mutation,
+        ["Upgraded"] = LifecycleStage.Mutation,
+        ["Downgraded"] = LifecycleStage.Mutation,
+        ["Approved"] = LifecycleStage.Mutation,
+        ["Rejected"] = LifecycleStage.Mutation,
+        ["Granted"] = LifecycleStage.Mutation,
+        ["Denied"] = LifecycleStage.Mutation,
+        ["Locked"] = LifecycleStage.Mutation,
+        ["Unlocked"] = LifecycleStage.Mutation,
+        ["Restored"] = LifecycleStage.Mutation
+    };
+
+    /// <summary>
+    /// Splits an event type name into its words, handling PascalCase, camelCase, acronyms, and
+    /// kebab/snake/dot separators.
+    /// </summary>
+    /// <param name="name">The event type name to split.</param>
+    /// <returns>The words making up the name, in order.</returns>
+    public static IReadOnlyList<string> SplitWords(string name)
+    {
+        var words = new List<string>();
+        var current = new System.Text.StringBuilder();
+
+        for (var index = 0; index < name.Length; index++)
+        {
+            var character = name[index];
+            if (character is '-' or '_' or '.' or ' ')
+            {
+                Flush(words, current);
+                continue;
+            }
+
+            if (char.IsUpper(character) && current.Length > 0)
+            {
+                var previous = name[index - 1];
+                var startsNewWord = char.IsLower(previous) || char.IsDigit(previous) ||
+                    (char.IsUpper(previous) && index + 1 < name.Length && char.IsLower(name[index + 1]));
+
+                if (startsNewWord)
+                {
+                    Flush(words, current);
+                }
+            }
+
+            current.Append(character);
+        }
+
+        Flush(words, current);
+        return words;
+    }
+
+    /// <summary>
+    /// Infers the entity (the subject noun phrase) an event type belongs to from its name.
+    /// </summary>
+    /// <param name="eventTypeName">The event type name.</param>
+    /// <returns>The inferred entity name, or the full name when no verb can be identified.</returns>
+    public static string InferEntity(string eventTypeName)
+    {
+        var words = SplitWords(eventTypeName);
+        var verbIndex = FindVerbIndex(words);
+
+        if (verbIndex <= 0)
+        {
+            return Capitalize(string.Concat(words));
+        }
+
+        return Capitalize(string.Concat(words.Take(verbIndex)));
+    }
+
+    /// <summary>
+    /// Classifies where in its entity's lifecycle an event sits, based on the verb in its name.
+    /// </summary>
+    /// <param name="eventTypeName">The event type name.</param>
+    /// <returns>The deduced <see cref="LifecycleStage"/>.</returns>
+    public static LifecycleStage Classify(string eventTypeName)
+    {
+        var words = SplitWords(eventTypeName);
+        var verbIndex = FindVerbIndex(words);
+
+        if (verbIndex < 0)
+        {
+            return LifecycleStage.Activity;
+        }
+
+        var phrase = string.Concat(words.Skip(verbIndex));
+        if (_verbStages.TryGetValue(phrase, out var phraseStage))
+        {
+            return phraseStage;
+        }
+
+        return _verbStages.TryGetValue(words[verbIndex], out var verbStage) ? verbStage : LifecycleStage.Activity;
+    }
+
+    static int FindVerbIndex(IReadOnlyList<string> words)
+    {
+        if (words.Count == 0)
+        {
+            return -1;
+        }
+
+        var lastIndex = words.Count - 1;
+        if (_particles.Contains(words[lastIndex]) && words.Count > 1)
+        {
+            lastIndex--;
+        }
+
+        return IsVerb(words[lastIndex]) ? lastIndex : -1;
+    }
+
+    static bool IsVerb(string word) =>
+        (word.Length > 2 && word.EndsWith("ed", StringComparison.OrdinalIgnoreCase)) ||
+        _irregularVerbs.Contains(word);
+
+    static string Capitalize(string value) =>
+        value.Length == 0 ? value : string.Concat(char.ToUpperInvariant(value[0]).ToString(), value[1..]);
+
+    static void Flush(List<string> words, System.Text.StringBuilder current)
+    {
+        if (current.Length > 0)
+        {
+            words.Add(current.ToString());
+            current.Clear();
+        }
+    }
+}

--- a/Source/Tools/Design/EventTypeSuggester.cs
+++ b/Source/Tools/Design/EventTypeSuggester.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Finds gaps in a system's deduced entity model and turns each into a grounded event type
+/// suggestion. Every rule is deterministic and explains itself: an entity without a beginning,
+/// a life without an end, or a fact set once and never changeable again.
+/// </summary>
+public static class EventTypeSuggester
+{
+    /// <summary>
+    /// Suggests event types to introduce next for the given entities.
+    /// </summary>
+    /// <param name="entities">The entities deduced from the store's event types.</param>
+    /// <returns>Suggestions grouped by entity, each with the gap it closes.</returns>
+    public static IReadOnlyList<EventTypeSuggestion> Suggest(IEnumerable<SystemEntity> entities) =>
+        entities.SelectMany(SuggestForEntity).ToList();
+
+    static IEnumerable<EventTypeSuggestion> SuggestForEntity(SystemEntity entity)
+    {
+        var creations = entity.Events.Where(entityEvent => entityEvent.Stage == LifecycleStage.Creation).ToList();
+        var hasTermination = entity.Events.Any(entityEvent => entityEvent.Stage == LifecycleStage.Termination);
+
+        if (creations.Count == 0)
+        {
+            var rationale =
+                $"The {entity.Name} lifecycle starts implicitly — its first recorded fact is '{entity.Events[0].EventType}'. " +
+                "An explicit creation event makes the beginning of the lifecycle unambiguous and gives projections a reliable initialization point.";
+            yield return new EventTypeSuggestion($"{entity.Name}Created", entity.Name, LifecycleStage.Creation, rationale, []);
+        }
+
+        if (!hasTermination)
+        {
+            var rationale =
+                $"The {entity.Name} lifecycle has a beginning but no end — nothing ever removes, closes, or archives a {entity.Name}. " +
+                "A termination event lets read models clear state (e.g. [RemovedWith]) and gives compliance and cleanup a fact to act on.";
+            yield return new EventTypeSuggestion($"{entity.Name}Removed", entity.Name, LifecycleStage.Termination, rationale, []);
+        }
+
+        foreach (var suggestion in SuggestChangeEvents(entity, creations))
+        {
+            yield return suggestion;
+        }
+    }
+
+    static IEnumerable<EventTypeSuggestion> SuggestChangeEvents(SystemEntity entity, IReadOnlyList<SystemEntityEvent> creations)
+    {
+        var laterPropertyNames = entity.Events
+            .Where(entityEvent => entityEvent.Stage != LifecycleStage.Creation)
+            .SelectMany(entityEvent => entityEvent.Properties)
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var creation in creations)
+        {
+            foreach (var property in creation.Properties)
+            {
+                if (property.Name.EndsWith("Id", StringComparison.OrdinalIgnoreCase) || laterPropertyNames.Contains(property.Name))
+                {
+                    continue;
+                }
+
+                var rationale =
+                    $"'{property.Name}' is set when the {entity.Name} comes to life ('{creation.EventType}') and no later event ever touches it. " +
+                    $"If the business allows a {entity.Name}'s {property.Name} to change, that change needs its own event.";
+                yield return new EventTypeSuggestion($"{entity.Name}{Capitalize(property.Name)}Changed", entity.Name, LifecycleStage.Mutation, rationale, [property]);
+            }
+        }
+    }
+
+    static string Capitalize(string value) =>
+        value.Length == 0 ? value : string.Concat(char.ToUpperInvariant(value[0]).ToString(), value[1..]);
+}

--- a/Source/Tools/Design/EventTypeSuggestion.cs
+++ b/Source/Tools/Design/EventTypeSuggestion.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A suggested event type to introduce next, grounded in a gap found in the store's current model.
+/// </summary>
+/// <param name="SuggestedName">The suggested event type name — past tense, one purpose, self-describing.</param>
+/// <param name="Entity">The entity whose lifecycle the suggestion completes.</param>
+/// <param name="Stage">The lifecycle stage the suggested event fills.</param>
+/// <param name="Rationale">Why this event is suggested — the concrete gap it closes.</param>
+/// <param name="SuggestedProperties">Properties the event could carry, drawn from the entity's existing schema vocabulary.</param>
+public record EventTypeSuggestion(
+    string SuggestedName,
+    string Entity,
+    LifecycleStage Stage,
+    string Rationale,
+    IReadOnlyList<EventSchemaProperty> SuggestedProperties);

--- a/Source/Tools/Design/LifecycleStage.cs
+++ b/Source/Tools/Design/LifecycleStage.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// The stage in an entity's lifecycle that an event represents, deduced from the event type's name.
+/// </summary>
+public enum LifecycleStage
+{
+    /// <summary>
+    /// The event brings an entity into existence (e.g. Registered, Created, Opened).
+    /// </summary>
+    Creation = 0,
+
+    /// <summary>
+    /// The event changes state the entity already has (e.g. Changed, Renamed, Assigned).
+    /// </summary>
+    Mutation = 1,
+
+    /// <summary>
+    /// The event records something that happened around the entity without defining its lifecycle
+    /// (e.g. Received, Shipped, LoggedIn).
+    /// </summary>
+    Activity = 2,
+
+    /// <summary>
+    /// The event corrects or reverses an earlier fact (e.g. Corrected, Adjusted, Redacted).
+    /// </summary>
+    Correction = 3,
+
+    /// <summary>
+    /// The event ends the entity's life (e.g. Removed, Closed, Cancelled).
+    /// </summary>
+    Termination = 4
+}

--- a/Source/Tools/Design/SystemAutomation.cs
+++ b/Source/Tools/Design/SystemAutomation.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// An automation in the system — a reactor or external observer that acts when events occur.
+/// Automations reveal what the system does on its own, without a user asking.
+/// </summary>
+/// <param name="Identifier">The observer identifier.</param>
+/// <param name="Type">The observer type (Reactor, External).</param>
+/// <param name="EventTypes">The event types that trigger the automation.</param>
+public record SystemAutomation(
+    string Identifier,
+    string Type,
+    IReadOnlyList<string> EventTypes);

--- a/Source/Tools/Design/SystemDescription.cs
+++ b/Source/Tools/Design/SystemDescription.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A deduced structural model of the system living in an event store — entities and their
+/// lifecycles read from event type names and schemas, the read surfaces built from them, and the
+/// automations reacting to them. The raw material for describing what the system is and telling
+/// its story.
+/// </summary>
+/// <param name="EventStore">The event store the description was deduced from.</param>
+/// <param name="Namespace">The namespace observers were resolved in.</param>
+/// <param name="Namespaces">All namespaces present in the event store.</param>
+/// <param name="Entities">The entities deduced from event type names, each with its lifecycle events.</param>
+/// <param name="ReadSurfaces">The read models built from the events — what the business watches.</param>
+/// <param name="Automations">The reactors and external observers — what the system does on its own.</param>
+/// <param name="UnconsumedEventTypes">Event types no projection, reducer, or reactor consumes — recorded facts nothing acts on yet.</param>
+/// <param name="Statistics">Headline numbers for the system.</param>
+/// <param name="NarrativeGuidance">Instructions for turning this structural model into a description and a story.</param>
+public record SystemDescription(
+    string EventStore,
+    string Namespace,
+    IReadOnlyList<string> Namespaces,
+    IReadOnlyList<SystemEntity> Entities,
+    IReadOnlyList<SystemReadSurface> ReadSurfaces,
+    IReadOnlyList<SystemAutomation> Automations,
+    IReadOnlyList<string> UnconsumedEventTypes,
+    SystemStatistics Statistics,
+    string NarrativeGuidance);

--- a/Source/Tools/Design/SystemDescriptionTools.cs
+++ b/Source/Tools/Design/SystemDescriptionTools.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Mcp.Configuration;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Design-time tool that deduces what the system in an event store is and is for. It reads the
+/// registered event types, their schemas, and the projections, reducers, and reactors around them,
+/// then clusters events into entities and lifecycles so an assistant can describe the system in
+/// domain language and tell its story — grounded in what the store actually contains.
+/// </summary>
+[McpServerToolType]
+public static class SystemDescriptionTools
+{
+    const string NarrativeGuidance =
+        "This is a structural model deduced from the store's registered metadata, not a finished description — " +
+        "turn it into one. (1) Say what the system is and is for: read the entity names, their events, and the " +
+        "property vocabulary as the system's ubiquitous language, and state the domain in plain words. " +
+        "(2) Tell the system's story entity by entity: how each comes to life (Creation events), what can happen " +
+        "to it along the way (Mutation and Activity events and the data they carry), how mistakes are handled " +
+        "(Correction events), and how its life ends (Termination events). (3) Weave in the read surfaces as what " +
+        "the business watches, and the automations as what the system does on its own when facts occur. " +
+        "(4) Mention unconsumed event types as facts the system records but does not yet act on. " +
+        "Stay grounded: describe only what the model evidences, and prefer the domain's own words over technical vocabulary.";
+
+    /// <summary>
+    /// Describes the system in an event store by deducing entities, lifecycles, read surfaces, and
+    /// automations from the registered metadata.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="eventStore">The event store to describe. Defaults to the configured event store.</param>
+    /// <param name="namespace">The namespace to resolve observers in. Defaults to the configured namespace.</param>
+    /// <returns>The deduced <see cref="SystemDescription"/>.</returns>
+    [McpServerTool(Name = "describe_system")]
+    [Description("Deduces what the system in an event store is and is for. Clusters event types into entities by name, places every event in its entity's lifecycle (creation, mutation, activity, correction, termination), and maps read surfaces and automations. Use it to describe a system in domain language or to tell the story of how the system behaves — the result carries narrative guidance for doing exactly that. Read-only introspection.")]
+    public static async Task<SystemDescription> DescribeSystem(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The event store to describe. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("The namespace to resolve observers in. Defaults to the configured namespace.")] string? @namespace = null)
+    {
+        var resolvedEventStore = configuration.ResolveEventStore(eventStore);
+        var resolvedNamespace = configuration.ResolveNamespace(@namespace);
+
+        var registrations = (await services.EventTypes.GetAllRegistrations(new GetAllEventTypesRequest { EventStore = resolvedEventStore })).ToList();
+        var projections = (await services.Projections.GetAllDefinitions(new Contracts.Projections.GetAllDefinitionsRequest { EventStore = resolvedEventStore })).ToList();
+        var observers = (await services.Observers.GetObservers(new AllObserversRequest { EventStore = resolvedEventStore, Namespace = resolvedNamespace })).ToList();
+        var readModels = (await services.ReadModels.GetDefinitions(new GetDefinitionsRequest { EventStore = resolvedEventStore })).ReadModels;
+        var namespaces = (await services.Namespaces.GetNamespaces(new GetNamespacesRequest { EventStore = resolvedEventStore })).ToList();
+
+        var schemasByEventType = LatestGenerations(registrations)
+            .ToDictionary(
+                registration => registration.Type.Id,
+                registration => EventSchemaParser.Parse(registration.Schema),
+                StringComparer.OrdinalIgnoreCase);
+
+        var entities = SystemModelAnalyzer.BuildEntities(schemasByEventType);
+        var consumerIndex = DesignIntrospection.BuildConsumerIndex(projections, observers, readModels);
+        var readSurfaces = ReadSurfaces(consumerIndex);
+        var automations = Automations(consumerIndex);
+        var unconsumed = schemasByEventType.Keys
+            .Where(eventTypeId => !consumerIndex.ContainsKey(eventTypeId))
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new SystemDescription(
+            resolvedEventStore,
+            resolvedNamespace,
+            namespaces,
+            entities,
+            readSurfaces,
+            automations,
+            unconsumed,
+            new SystemStatistics(schemasByEventType.Count, entities.Count, readSurfaces.Count, automations.Count, namespaces.Count),
+            NarrativeGuidance);
+    }
+
+    static IEnumerable<EventTypeRegistration> LatestGenerations(IEnumerable<EventTypeRegistration> registrations) =>
+        registrations
+            .GroupBy(registration => registration.Type.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.OrderByDescending(registration => registration.Type.Generation).First());
+
+    static bool BuildsReadModel(EventCatalogConsumer consumer) =>
+        string.Equals(consumer.Type, nameof(ObserverType.Projection), StringComparison.Ordinal) ||
+        string.Equals(consumer.Type, nameof(ObserverType.Reducer), StringComparison.Ordinal);
+
+    static List<SystemReadSurface> ReadSurfaces(IReadOnlyDictionary<string, IReadOnlyList<EventCatalogConsumer>> consumerIndex) =>
+        InvertIndex(consumerIndex, BuildsReadModel)
+            .Select(entry => new SystemReadSurface(entry.Consumer.ReadModel ?? entry.Consumer.Id, entry.Consumer.Type, entry.EventTypes))
+            .OrderBy(surface => surface.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    static List<SystemAutomation> Automations(IReadOnlyDictionary<string, IReadOnlyList<EventCatalogConsumer>> consumerIndex) =>
+        InvertIndex(consumerIndex, consumer => !BuildsReadModel(consumer))
+            .Select(entry => new SystemAutomation(entry.Consumer.Id, entry.Consumer.Type, entry.EventTypes))
+            .OrderBy(automation => automation.Identifier, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    static IEnumerable<(EventCatalogConsumer Consumer, IReadOnlyList<string> EventTypes)> InvertIndex(
+        IReadOnlyDictionary<string, IReadOnlyList<EventCatalogConsumer>> consumerIndex,
+        Func<EventCatalogConsumer, bool> predicate) =>
+        consumerIndex
+            .SelectMany(entry => entry.Value
+                .Where(predicate)
+                .Select(consumer => (consumer, EventType: entry.Key)))
+            .GroupBy(pair => (pair.consumer.Type, pair.consumer.Id))
+            .Select(group => (
+                group.First().consumer,
+                (IReadOnlyList<string>)group
+                    .Select(pair => pair.EventType)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Order(StringComparer.OrdinalIgnoreCase)
+                    .ToList()));
+}

--- a/Source/Tools/Design/SystemEntity.cs
+++ b/Source/Tools/Design/SystemEntity.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// An entity deduced from the event type names in a store — the subject that a cluster of
+/// events describe the life of.
+/// </summary>
+/// <param name="Name">The inferred entity name (e.g. "Author" from AuthorRegistered/AuthorRenamed).</param>
+/// <param name="Events">The events describing the entity's life, ordered by lifecycle stage.</param>
+public record SystemEntity(
+    string Name,
+    IReadOnlyList<SystemEntityEvent> Events);

--- a/Source/Tools/Design/SystemEntityEvent.cs
+++ b/Source/Tools/Design/SystemEntityEvent.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// An event type placed within its entity's lifecycle, with the properties it carries.
+/// </summary>
+/// <param name="EventType">The event type id as registered in the store.</param>
+/// <param name="Stage">Where in the entity's lifecycle the event sits, deduced from its name.</param>
+/// <param name="Properties">The properties the event carries, parsed from its registered schema.</param>
+public record SystemEntityEvent(
+    string EventType,
+    LifecycleStage Stage,
+    IReadOnlyList<EventSchemaProperty> Properties);

--- a/Source/Tools/Design/SystemEvolutionSuggestions.cs
+++ b/Source/Tools/Design/SystemEvolutionSuggestions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// The result of analyzing a system for event types worth introducing next — grounded gap
+/// findings, not finished designs.
+/// </summary>
+/// <param name="EventStore">The event store that was analyzed.</param>
+/// <param name="Entities">The entities the analysis was performed over.</param>
+/// <param name="Suggestions">The suggested event types with the gap each one closes.</param>
+/// <param name="Guidance">Instructions for refining the suggestions with domain knowledge.</param>
+public record SystemEvolutionSuggestions(
+    string EventStore,
+    IReadOnlyList<SystemEntity> Entities,
+    IReadOnlyList<EventTypeSuggestion> Suggestions,
+    string Guidance);

--- a/Source/Tools/Design/SystemEvolutionTools.cs
+++ b/Source/Tools/Design/SystemEvolutionTools.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Mcp.Configuration;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Design-time tool that suggests which event types to introduce next. It deduces the system's
+/// entities and lifecycles from the registered event types, then finds the gaps: lifecycles
+/// without a beginning or an end, and facts set at creation that no event can ever change.
+/// </summary>
+[McpServerToolType]
+public static class SystemEvolutionTools
+{
+    const string Guidance =
+        "These suggestions are deterministic gap findings grounded in the store's registered event types — seeds, " +
+        "not finished designs. Refine them with domain knowledge: rename to the domain's own ubiquitous language " +
+        "(e.g. a Book is 'Withdrawn', not 'Removed'; an Order is 'Cancelled', not 'Deleted'), discard any that the " +
+        "business genuinely never needs (some facts really are immutable), and propose properties drawn from the " +
+        "existing schema vocabulary. Keep every event past tense, single purpose, and self-describing, and never " +
+        "add a nullable property — an optional fact is its own event.";
+
+    /// <summary>
+    /// Suggests event types to introduce next for the system in an event store.
+    /// </summary>
+    /// <param name="services">The Chronicle services.</param>
+    /// <param name="configuration">The connection configuration used to resolve defaults.</param>
+    /// <param name="eventStore">The event store to analyze. Defaults to the configured event store.</param>
+    /// <param name="entity">An optional entity name to scope the suggestions to.</param>
+    /// <returns>The <see cref="SystemEvolutionSuggestions"/> with grounded suggestions and refinement guidance.</returns>
+    [McpServerTool(Name = "suggest_next_event_types")]
+    [Description("Suggests event types to introduce next for the system in an event store. Deduces entities and lifecycles from the registered event type names and schemas, then finds concrete gaps: entities without an explicit creation event, lifecycles with no termination, and creation-time properties no event can ever change. Each suggestion carries the gap it closes and candidate properties from the existing schema. Read-only introspection; refine the results with domain knowledge.")]
+    public static async Task<SystemEvolutionSuggestions> SuggestNextEventTypes(
+        IServices services,
+        ChronicleConnectionConfiguration configuration,
+        [Description("The event store to analyze. Defaults to the configured event store.")] string? eventStore = null,
+        [Description("An optional entity name to scope the suggestions to (case-insensitive).")] string? entity = null)
+    {
+        var resolvedEventStore = configuration.ResolveEventStore(eventStore);
+
+        var registrations = (await services.EventTypes.GetAllRegistrations(new GetAllEventTypesRequest { EventStore = resolvedEventStore })).ToList();
+
+        var schemasByEventType = registrations
+            .GroupBy(registration => registration.Type.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.OrderByDescending(registration => registration.Type.Generation).First())
+            .ToDictionary(
+                registration => registration.Type.Id,
+                registration => EventSchemaParser.Parse(registration.Schema),
+                StringComparer.OrdinalIgnoreCase);
+
+        var entities = SystemModelAnalyzer.BuildEntities(schemasByEventType)
+            .Where(candidate => string.IsNullOrWhiteSpace(entity) || string.Equals(candidate.Name, entity, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        return new SystemEvolutionSuggestions(
+            resolvedEventStore,
+            entities,
+            EventTypeSuggester.Suggest(entities),
+            Guidance);
+    }
+}

--- a/Source/Tools/Design/SystemModelAnalyzer.cs
+++ b/Source/Tools/Design/SystemModelAnalyzer.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Deduces a structural model of a system from its registered event types — clustering events into
+/// the entities they describe and placing each event in that entity's lifecycle. This is the shared
+/// deduction underneath the system description and evolution suggestion tools.
+/// </summary>
+public static class SystemModelAnalyzer
+{
+    /// <summary>
+    /// Builds the entity model for a set of event types and their schema properties.
+    /// </summary>
+    /// <param name="eventTypes">The event type ids with the properties parsed from their schemas.</param>
+    /// <returns>The deduced entities, alphabetically ordered, each with its events ordered by lifecycle stage.</returns>
+    /// <remarks>
+    /// Property-scoped clusters coalesce into their parent entity when one exists: with both
+    /// AuthorRegistered and AuthorNameChanged present, "AuthorName" folds into "Author" so the
+    /// entity's full lifecycle sits together.
+    /// </remarks>
+    public static IReadOnlyList<SystemEntity> BuildEntities(IReadOnlyDictionary<string, IReadOnlyList<EventSchemaProperty>> eventTypes)
+    {
+        var clusters = eventTypes
+            .Select(eventType => new
+            {
+                Entity = EventNameMorphology.InferEntity(eventType.Key),
+                Event = new SystemEntityEvent(eventType.Key, EventNameMorphology.Classify(eventType.Key), eventType.Value)
+            })
+            .GroupBy(entry => entry.Entity, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Select(entry => entry.Event).ToList(), StringComparer.OrdinalIgnoreCase);
+
+        return clusters
+            .GroupBy(cluster => Canonical(cluster.Key, clusters), StringComparer.OrdinalIgnoreCase)
+            .Select(group => new SystemEntity(
+                group.Key,
+                group
+                    .SelectMany(cluster => cluster.Value)
+                    .OrderBy(entityEvent => StageOrder(entityEvent.Stage))
+                    .ThenBy(entityEvent => entityEvent.EventType, StringComparer.OrdinalIgnoreCase)
+                    .ToList()))
+            .OrderBy(entity => entity.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    static string Canonical(string entity, IReadOnlyDictionary<string, List<SystemEntityEvent>> clusters)
+    {
+        var current = entity;
+        var parent = LongestKnownPrefix(current, clusters);
+        while (parent is not null)
+        {
+            current = parent;
+            parent = LongestKnownPrefix(current, clusters);
+        }
+
+        return current;
+    }
+
+    static string? LongestKnownPrefix(string entity, IReadOnlyDictionary<string, List<SystemEntityEvent>> clusters)
+    {
+        var words = EventNameMorphology.SplitWords(entity);
+        for (var length = words.Count - 1; length >= 1; length--)
+        {
+            var candidate = string.Concat(words.Take(length));
+            if (clusters.ContainsKey(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    static int StageOrder(LifecycleStage stage) => stage switch
+    {
+        LifecycleStage.Creation => 0,
+        LifecycleStage.Mutation => 1,
+        LifecycleStage.Activity => 2,
+        LifecycleStage.Correction => 3,
+        LifecycleStage.Termination => 4,
+        _ => 5
+    };
+}

--- a/Source/Tools/Design/SystemPrompts.cs
+++ b/Source/Tools/Design/SystemPrompts.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Prompts that package the system-analysis workflows so MCP clients can offer them directly
+/// (for example as slash commands), pairing the analysis tools with the narrative work the
+/// client's model performs.
+/// </summary>
+[McpServerPromptType]
+public static class SystemPrompts
+{
+    /// <summary>
+    /// Prompt for describing the system in an event store and telling its story.
+    /// </summary>
+    /// <param name="eventStore">The event store to describe; empty uses the configured default.</param>
+    /// <returns>The prompt text.</returns>
+    [McpServerPrompt(Name = "describe_system")]
+    [Description("Describe what the system in an event store is and is for, and tell its story — deduced from the event types, their names and properties, and the read models and automations around them.")]
+    public static string DescribeSystem(
+        [Description("The event store to describe. Leave empty to use the configured default.")] string? eventStore = null) =>
+        $"Call the describe_system tool{ForEventStore(eventStore)}. From its result, produce two things:\n" +
+        "1. A description of what this system is and what it is for, written in the domain's own language — " +
+        "deduce the domain from the entity names, event vocabulary, and property names.\n" +
+        "2. The story of the system: walk through each entity's life from the events — how it comes into being, " +
+        "what happens to it, and how it ends — and weave in what the business watches (read surfaces) and what " +
+        "the system does on its own (automations). Follow the narrative guidance carried in the result.";
+
+    /// <summary>
+    /// Prompt for suggesting the next event types to introduce for a system.
+    /// </summary>
+    /// <param name="eventStore">The event store to analyze; empty uses the configured default.</param>
+    /// <returns>The prompt text.</returns>
+    [McpServerPrompt(Name = "suggest_next_event_types")]
+    [Description("Suggest which event types to introduce next for the system in an event store, grounded in gaps found in the registered event types and refined with domain knowledge.")]
+    public static string SuggestNextEventTypes(
+        [Description("The event store to analyze. Leave empty to use the configured default.")] string? eventStore = null) =>
+        $"Call the suggest_next_event_types tool{ForEventStore(eventStore)}. Present each suggestion with the gap " +
+        "it closes, refine the names to the domain's ubiquitous language, and discard any suggestion the business " +
+        "genuinely would not need — explain why in each case. Follow the guidance carried in the result, and keep " +
+        "every proposed event past tense, single purpose, and free of nullable properties.";
+
+    /// <summary>
+    /// Prompt for answering a natural-language query with an ad-hoc projection.
+    /// </summary>
+    /// <param name="query">The natural-language question to answer (e.g. "show all employees with all details").</param>
+    /// <param name="eventStore">The event store to query; empty uses the configured default.</param>
+    /// <returns>The prompt text.</returns>
+    [McpServerPrompt(Name = "query_system")]
+    [Description("Answer a natural-language question about the data in an event store — resolves which event types are involved and materializes the answer with an ad-hoc projection, without registering anything.")]
+    public static string QuerySystem(
+        [Description("The natural-language question to answer, e.g. 'show all employees with all details'.")] string query,
+        [Description("The event store to query. Leave empty to use the configured default.")] string? eventStore = null) =>
+        $"Answer this question about the system{ForEventStore(eventStore)}: \"{query}\".\n" +
+        "1. Call describe_system (or generate_event_catalog) to learn the entities and their event types.\n" +
+        "2. Decide which event types carry the facts the question asks about — include every event type that " +
+        "contributes details, and identify any termination events that should remove instances from the answer.\n" +
+        "3. Call run_ad_hoc_projection with those event types (and removedWith for the termination events).\n" +
+        "4. Present the instances in the domain's language — a table when they share a shape — and follow the " +
+        "guidance carried in the result. If the question recurs, suggest making the projection permanent with scaffold_read_model.";
+
+    static string ForEventStore(string? eventStore) =>
+        string.IsNullOrWhiteSpace(eventStore) ? string.Empty : $" for the '{eventStore}' event store";
+}

--- a/Source/Tools/Design/SystemReadSurface.cs
+++ b/Source/Tools/Design/SystemReadSurface.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// A read surface of the system — a read model built by a projection or reducer. Read surfaces
+/// reveal what the business actually watches: the questions the system exists to answer.
+/// </summary>
+/// <param name="Name">The read model name, or the observer identifier when no read model name is known.</param>
+/// <param name="BuiltBy">How the surface is built: Projection or Reducer.</param>
+/// <param name="EventTypes">The event types the surface is derived from.</param>
+public record SystemReadSurface(
+    string Name,
+    string BuiltBy,
+    IReadOnlyList<string> EventTypes);

--- a/Source/Tools/Design/SystemStatistics.cs
+++ b/Source/Tools/Design/SystemStatistics.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Mcp.Tools.Design;
+
+/// <summary>
+/// Headline numbers for a described system.
+/// </summary>
+/// <param name="EventTypes">The number of distinct event types registered.</param>
+/// <param name="Entities">The number of entities deduced from the event type names.</param>
+/// <param name="ReadSurfaces">The number of read surfaces (projections and reducers).</param>
+/// <param name="Automations">The number of automations (reactors and external observers).</param>
+/// <param name="Namespaces">The number of namespaces in the event store.</param>
+public record SystemStatistics(
+    int EventTypes,
+    int Entities,
+    int ReadSurfaces,
+    int Automations,
+    int Namespaces);

--- a/Specs/Chronicle.Mcp.Specs/Chronicle.Mcp.Specs.csproj
+++ b/Specs/Chronicle.Mcp.Specs/Chronicle.Mcp.Specs.csproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Chronicle.Mcp.Specs</AssemblyName>
+        <RootNamespace>Cratis.Chronicle.Mcp</RootNamespace>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <NoWarn>$(NoWarn);CS1591;IDE1006;IDE0005;MA0101;RCS1266;xUnit1031</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Cratis.Specifications.XUnit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../../Source/Chronicle.Mcp.csproj" />
+    </ItemGroup>
+</Project>

--- a/Specs/Chronicle.Mcp.Specs/GlobalUsings.cs
+++ b/Specs/Chronicle.Mcp.Specs/GlobalUsings.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable IDE0005 // Using directive is unnecessary.
+
+global using Cratis.Specifications;
+global using Xunit;

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_AdHocProjector/when_folding_events_for_multiple_sources.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_AdHocProjector/when_folding_events_for_multiple_sources.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_AdHocProjector;
+
+public class when_folding_events_for_multiple_sources : Specification
+{
+    static readonly DateTimeOffset _first = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    static readonly DateTimeOffset _second = new(2026, 2, 1, 0, 0, 0, TimeSpan.Zero);
+
+    IReadOnlyList<AdHocProjectionInstance> _result;
+
+    static JsonElement Json(string json) => JsonSerializer.Deserialize<JsonElement>(json);
+
+    void Because() => _result = AdHocProjector.Fold(
+    [
+        new AdHocEvent("employee-2", "EmployeeHired", 3, _second, Json("""{"Name":"Kari","Title":"Engineer"}""")),
+        new AdHocEvent("employee-1", "EmployeeHired", 0, _first, Json("""{"Name":"Ola","Title":"Engineer"}""")),
+        new AdHocEvent("employee-1", "EmployeePromoted", 5, _second, Json("""{"Title":"Architect"}"""))
+    ]);
+
+    [Fact] void should_materialize_one_instance_per_event_source() => _result.Count.ShouldEqual(2);
+    [Fact] void should_order_instances_by_event_source_id() => _result.Select(instance => instance.EventSourceId).ShouldEqual("employee-1", "employee-2");
+    [Fact] void should_let_later_events_overwrite_property_values() => _result[0].Properties["Title"].GetString().ShouldEqual("Architect");
+    [Fact] void should_keep_properties_untouched_by_later_events() => _result[0].Properties["Name"].GetString().ShouldEqual("Ola");
+    [Fact] void should_track_the_last_folded_sequence_number() => _result[0].LastEventSequenceNumber.ShouldEqual(5UL);
+    [Fact] void should_track_when_the_last_event_occurred() => _result[0].LastOccurred.ShouldEqual(_second);
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_AdHocProjector/when_folding_with_removal_events.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_AdHocProjector/when_folding_with_removal_events.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_AdHocProjector;
+
+public class when_folding_with_removal_events : Specification
+{
+    IReadOnlyList<AdHocProjectionInstance> _result;
+
+    static JsonElement Json(string json) => JsonSerializer.Deserialize<JsonElement>(json);
+
+    void Because() => _result = AdHocProjector.Fold(
+    [
+        new AdHocEvent("employee-1", "EmployeeHired", 0, null, Json("""{"Name":"Ola"}""")),
+        new AdHocEvent("employee-2", "EmployeeHired", 1, null, Json("""{"Name":"Kari"}""")),
+        new AdHocEvent("employee-1", "EmployeeTerminated", 2, null, null),
+        new AdHocEvent("employee-3", "EmployeeHired", 3, null, Json("""{"Name":"Per"}""")),
+        new AdHocEvent("employee-3", "EmployeeTerminated", 4, null, null),
+        new AdHocEvent("employee-3", "EmployeeHired", 5, null, Json("""{"Name":"Per Again"}"""))
+    ],
+    ["EmployeeTerminated"]);
+
+    [Fact] void should_drop_removed_instances() => _result.ShouldNotContain(instance => instance.EventSourceId == "employee-1");
+    [Fact] void should_keep_instances_that_were_not_removed() => _result.ShouldContain(instance => instance.EventSourceId == "employee-2");
+    [Fact] void should_let_later_events_recreate_a_removed_instance() => _result.Single(instance => instance.EventSourceId == "employee-3").Properties["Name"].GetString().ShouldEqual("Per Again");
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventNameMorphology/when_classifying_lifecycle.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventNameMorphology/when_classifying_lifecycle.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_EventNameMorphology;
+
+public class when_classifying_lifecycle : Specification
+{
+    [Fact] void should_classify_registered_as_creation() => EventNameMorphology.Classify("AuthorRegistered").ShouldEqual(LifecycleStage.Creation);
+    [Fact] void should_classify_hired_as_creation() => EventNameMorphology.Classify("EmployeeHired").ShouldEqual(LifecycleStage.Creation);
+    [Fact] void should_classify_signed_up_as_creation() => EventNameMorphology.Classify("UserSignedUp").ShouldEqual(LifecycleStage.Creation);
+    [Fact] void should_classify_changed_as_mutation() => EventNameMorphology.Classify("AuthorNameChanged").ShouldEqual(LifecycleStage.Mutation);
+    [Fact] void should_classify_set_as_mutation() => EventNameMorphology.Classify("EmployeeAddressSet").ShouldEqual(LifecycleStage.Mutation);
+    [Fact] void should_classify_removed_as_termination() => EventNameMorphology.Classify("AuthorRemoved").ShouldEqual(LifecycleStage.Termination);
+    [Fact] void should_classify_cancelled_as_termination() => EventNameMorphology.Classify("OrderCancelled").ShouldEqual(LifecycleStage.Termination);
+    [Fact] void should_classify_corrected_as_correction() => EventNameMorphology.Classify("InvoiceCorrected").ShouldEqual(LifecycleStage.Correction);
+    [Fact] void should_classify_redacted_as_correction() => EventNameMorphology.Classify("EventRedacted").ShouldEqual(LifecycleStage.Correction);
+    [Fact] void should_classify_unknown_verb_as_activity() => EventNameMorphology.Classify("PaymentReceived").ShouldEqual(LifecycleStage.Activity);
+    [Fact] void should_classify_logged_in_as_activity() => EventNameMorphology.Classify("UserLoggedIn").ShouldEqual(LifecycleStage.Activity);
+    [Fact] void should_classify_name_without_verb_as_activity() => EventNameMorphology.Classify("OrderShipment").ShouldEqual(LifecycleStage.Activity);
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventNameMorphology/when_inferring_entity.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventNameMorphology/when_inferring_entity.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_EventNameMorphology;
+
+public class when_inferring_entity : Specification
+{
+    [Fact] void should_infer_from_simple_creation_event() => EventNameMorphology.InferEntity("AuthorRegistered").ShouldEqual("Author");
+    [Fact] void should_infer_multi_word_entity() => EventNameMorphology.InferEntity("OrderLineAdded").ShouldEqual("OrderLine");
+    [Fact] void should_infer_entity_when_verb_has_particle() => EventNameMorphology.InferEntity("UserLoggedIn").ShouldEqual("User");
+    [Fact] void should_infer_entity_from_irregular_verb() => EventNameMorphology.InferEntity("InvoiceSent").ShouldEqual("Invoice");
+    [Fact] void should_use_full_name_when_no_verb_is_found() => EventNameMorphology.InferEntity("OrderShipment").ShouldEqual("OrderShipment");
+    [Fact] void should_use_full_name_when_name_is_only_a_verb() => EventNameMorphology.InferEntity("Registered").ShouldEqual("Registered");
+    [Fact] void should_capitalize_camel_case_names() => EventNameMorphology.InferEntity("authorRegistered").ShouldEqual("Author");
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventNameMorphology/when_splitting_words.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventNameMorphology/when_splitting_words.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_EventNameMorphology;
+
+public class when_splitting_words : Specification
+{
+    [Fact] void should_split_pascal_case() => EventNameMorphology.SplitWords("AuthorRegistered").ShouldEqual("Author", "Registered");
+    [Fact] void should_split_camel_case() => EventNameMorphology.SplitWords("authorRegistered").ShouldEqual("author", "Registered");
+    [Fact] void should_keep_acronyms_together() => EventNameMorphology.SplitWords("PIIRemoved").ShouldEqual("PII", "Removed");
+    [Fact] void should_split_kebab_case() => EventNameMorphology.SplitWords("author-registered").ShouldEqual("author", "registered");
+    [Fact] void should_split_snake_case() => EventNameMorphology.SplitWords("author_registered").ShouldEqual("author", "registered");
+    [Fact] void should_split_multi_word_entity() => EventNameMorphology.SplitWords("OrderLineAdded").ShouldEqual("Order", "Line", "Added");
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventTypeSuggester/when_creation_property_is_never_mutated.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventTypeSuggester/when_creation_property_is_never_mutated.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_EventTypeSuggester;
+
+public class when_creation_property_is_never_mutated : Specification
+{
+    static readonly EventSchemaProperty _customerId = new("CustomerId", "string", "Guid", "guid", true, null);
+    static readonly EventSchemaProperty _email = new("Email", "string", "string", null, true, null);
+    static readonly EventSchemaProperty _name = new("Name", "string", "string", null, true, null);
+
+    IReadOnlyList<EventTypeSuggestion> _result;
+
+    void Because() => _result = EventTypeSuggester.Suggest(
+    [
+        new SystemEntity("Customer",
+        [
+            new SystemEntityEvent("CustomerRegistered", LifecycleStage.Creation, [_customerId, _email, _name]),
+            new SystemEntityEvent("CustomerNameChanged", LifecycleStage.Mutation, [_name]),
+            new SystemEntityEvent("CustomerRemoved", LifecycleStage.Termination, [])
+        ])
+    ]);
+
+    [Fact] void should_suggest_a_change_event_for_the_untouched_property() => _result.Single().SuggestedName.ShouldEqual("CustomerEmailChanged");
+    [Fact] void should_not_suggest_for_identifier_properties() => _result.ShouldNotContain(suggestion => suggestion.SuggestedName.Contains("CustomerId"));
+    [Fact] void should_not_suggest_for_properties_already_mutated() => _result.ShouldNotContain(suggestion => suggestion.SuggestedName.Contains("Name"));
+    [Fact] void should_carry_the_property_on_the_suggestion() => _result.Single().SuggestedProperties.Single().ShouldEqual(_email);
+    [Fact] void should_name_the_creation_event_in_the_rationale() => _result.Single().Rationale.ShouldContain("CustomerRegistered");
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventTypeSuggester/when_entity_has_creation_but_no_termination.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventTypeSuggester/when_entity_has_creation_but_no_termination.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_EventTypeSuggester;
+
+public class when_entity_has_creation_but_no_termination : Specification
+{
+    IReadOnlyList<EventTypeSuggestion> _result;
+
+    void Because() => _result = EventTypeSuggester.Suggest(
+    [
+        new SystemEntity("Author",
+        [
+            new SystemEntityEvent("AuthorRegistered", LifecycleStage.Creation, [])
+        ])
+    ]);
+
+    [Fact] void should_suggest_a_termination_event() => _result.Single().SuggestedName.ShouldEqual("AuthorRemoved");
+    [Fact] void should_target_the_entity() => _result.Single().Entity.ShouldEqual("Author");
+    [Fact] void should_fill_the_termination_stage() => _result.Single().Stage.ShouldEqual(LifecycleStage.Termination);
+    [Fact] void should_explain_the_gap() => _result.Single().Rationale.ShouldContain("no end");
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventTypeSuggester/when_entity_has_no_creation.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventTypeSuggester/when_entity_has_no_creation.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_EventTypeSuggester;
+
+public class when_entity_has_no_creation : Specification
+{
+    IReadOnlyList<EventTypeSuggestion> _result;
+
+    void Because() => _result = EventTypeSuggester.Suggest(
+    [
+        new SystemEntity("Order",
+        [
+            new SystemEntityEvent("OrderCancelled", LifecycleStage.Termination, [])
+        ])
+    ]);
+
+    [Fact] void should_suggest_a_creation_event() => _result.Single().SuggestedName.ShouldEqual("OrderCreated");
+    [Fact] void should_fill_the_creation_stage() => _result.Single().Stage.ShouldEqual(LifecycleStage.Creation);
+    [Fact] void should_name_the_first_recorded_fact_in_the_rationale() => _result.Single().Rationale.ShouldContain("OrderCancelled");
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventTypeSuggester/when_entity_lifecycle_is_complete.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_EventTypeSuggester/when_entity_lifecycle_is_complete.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_EventTypeSuggester;
+
+public class when_entity_lifecycle_is_complete : Specification
+{
+    static readonly EventSchemaProperty _name = new("Name", "string", "string", null, true, null);
+
+    IReadOnlyList<EventTypeSuggestion> _result;
+
+    void Because() => _result = EventTypeSuggester.Suggest(
+    [
+        new SystemEntity("Author",
+        [
+            new SystemEntityEvent("AuthorRegistered", LifecycleStage.Creation, [_name]),
+            new SystemEntityEvent("AuthorNameChanged", LifecycleStage.Mutation, [_name]),
+            new SystemEntityEvent("AuthorRemoved", LifecycleStage.Termination, [])
+        ])
+    ]);
+
+    [Fact] void should_have_nothing_to_suggest() => _result.ShouldBeEmpty();
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_SystemModelAnalyzer/when_building_entities_from_mixed_event_types.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_SystemModelAnalyzer/when_building_entities_from_mixed_event_types.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_SystemModelAnalyzer;
+
+public class when_building_entities_from_mixed_event_types : Specification
+{
+    static readonly EventSchemaProperty _name = new("Name", "string", "string", null, true, null);
+
+    IReadOnlyList<SystemEntity> _result;
+
+    void Because() => _result = SystemModelAnalyzer.BuildEntities(new Dictionary<string, IReadOnlyList<EventSchemaProperty>>
+    {
+        ["AuthorRemoved"] = [],
+        ["AuthorRegistered"] = [_name],
+        ["AuthorNameChanged"] = [_name],
+        ["BookAdded"] = []
+    });
+
+    [Fact] void should_deduce_two_entities() => _result.Count.ShouldEqual(2);
+    [Fact] void should_order_entities_alphabetically() => _result.Select(entity => entity.Name).ShouldEqual("Author", "Book");
+    [Fact] void should_cluster_all_author_events() => _result[0].Events.Count.ShouldEqual(3);
+    [Fact] void should_order_events_by_lifecycle_stage() => _result[0].Events.Select(entityEvent => entityEvent.EventType).ShouldEqual("AuthorRegistered", "AuthorNameChanged", "AuthorRemoved");
+    [Fact] void should_carry_the_schema_properties() => _result[0].Events[0].Properties.Single().ShouldEqual(_name);
+    [Fact] void should_classify_each_event() => _result[0].Events[0].Stage.ShouldEqual(LifecycleStage.Creation);
+}

--- a/Specs/Chronicle.Mcp.Specs/Tools/Design/for_SystemModelAnalyzer/when_coalescing_property_scoped_clusters.cs
+++ b/Specs/Chronicle.Mcp.Specs/Tools/Design/for_SystemModelAnalyzer/when_coalescing_property_scoped_clusters.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Mcp.Tools.Design;
+
+namespace Cratis.Chronicle.Mcp.Specs.Tools.Design.for_SystemModelAnalyzer;
+
+public class when_coalescing_property_scoped_clusters : Specification
+{
+    IReadOnlyList<SystemEntity> _withParent;
+    IReadOnlyList<SystemEntity> _withoutParent;
+
+    void Because()
+    {
+        _withParent = SystemModelAnalyzer.BuildEntities(new Dictionary<string, IReadOnlyList<EventSchemaProperty>>
+        {
+            ["CustomerRegistered"] = [],
+            ["CustomerAddressUpdated"] = []
+        });
+
+        _withoutParent = SystemModelAnalyzer.BuildEntities(new Dictionary<string, IReadOnlyList<EventSchemaProperty>>
+        {
+            ["CustomerAddressUpdated"] = []
+        });
+    }
+
+    [Fact] void should_fold_the_property_scoped_cluster_into_its_parent() => _withParent.Single().Name.ShouldEqual("Customer");
+    [Fact] void should_keep_both_events_on_the_parent() => _withParent.Single().Events.Count.ShouldEqual(2);
+    [Fact] void should_keep_the_cluster_standalone_without_a_parent() => _withoutParent.Single().Name.ShouldEqual("CustomerAddress");
+}


### PR DESCRIPTION
# Summary

The MCP server grows from static data checks into system understanding: it can now deduce what the system in an event store *is and is for* from the registered event types, suggest how the event model should evolve, and answer natural-language questions like "show all employees with all details" by projecting events on demand — nothing registered, nothing written.

## Added

- `describe_system` tool that deduces the system in an event store — clustering event types into entities, placing every event in its entity's lifecycle, and mapping read surfaces and automations — with narrative guidance for describing the system and telling its story
- `suggest_next_event_types` tool that finds lifecycle gaps (no explicit creation, a life without an end, facts frozen at creation) and suggests grounded event types to introduce next
- `run_ad_hoc_projection` tool that folds events into per-event-source instances on demand with AutoMap semantics, answering ad-hoc queries without registering a projection
- MCP prompts `describe_system`, `suggest_next_event_types`, and `query_system` packaging the workflows for clients that surface prompts
- Documentation for the new capabilities in the design-time docs, README, and getting started

## Changed

- Updated all dependencies to their latest versions, including Chronicle 16.11.1 and the MCP SDK 2.0.0
- The default connection string is now `chronicle://localhost:35000` — Chronicle 16.11 removed the `disableTls` flag; the client always uses TLS, with `skipTlsValidation` controlling certificate validation
